### PR TITLE
allow selecting a specific path on getLog (avoids fetching the treeobject before)

### DIFF
--- a/src/GitElephant/Command/LogCommand.php
+++ b/src/GitElephant/Command/LogCommand.php
@@ -48,21 +48,21 @@ class LogCommand extends BaseCommand
                 $subject .= (string) $branch;
             }
         }
-        $subject .= ' -- ' . $obj->getFullPath();
 
-        return $this->showLog($subject, $limit, $offset);
+        return $this->showLog($subject, $obj->getFullPath(), $limit, $offset);
     }
 
     /**
      * Build a generic log command
      *
      * @param \GitElephant\Objects\TreeishInterface|string $ref    the reference to build the log for
+     * @param string|null                                  $path   the physical path to the tree relative to the repository root
      * @param int|null                                     $limit  limit to n entries
      * @param int|null                                     $offset skip n entries
      *
      * @return string
      */
-    public function showLog($ref, $limit = null, $offset = null)
+    public function showLog($ref, $path = null, $limit = null, $offset = null)
     {
         $this->clearAll();
 
@@ -83,6 +83,10 @@ class LogCommand extends BaseCommand
 
         if ($ref instanceof \GitElephant\Objects\TreeishInterface) {
             $ref = $ref->getSha();
+        }
+
+        if (null !== $path && !empty($path)) {
+            $ref .= ' -- ' . $path;
         }
 
         $this->addCommandSubject($ref);

--- a/src/GitElephant/Repository.php
+++ b/src/GitElephant/Repository.php
@@ -312,15 +312,16 @@ class Repository
     /**
      * Get a log for a ref
      *
-     * @param \GitElephant\Objects\TreeishInterface|string|null $ref    The reference to build the log for
-     * @param int|null                                          $limit  Limit to n entries
-     * @param int|null                                          $offset Skip n entries
+     * @param string|TreeishInterface $ref    the treeish to check
+     * @param string|TreeObject       $path   the physical path to the tree relative to the repository root
+     * @param int|null                $limit  limit to n entries
+     * @param int|null                $offset skip n entries
      *
      * @return \GitElephant\Objects\Log
      */
-    public function getLog($ref = null, $limit = 15, $offset = null)
+    public function getLog($ref = 'HEAD', $path = null, $limit = 15, $offset = null)
     {
-        $command = $this->container->get('command.log')->showLog($ref, $limit, $offset);
+        $command = $this->container->get('command.log')->showLog($ref, $path, $limit, $offset);
         return new Log($this->caller->execute($command)->getOutputLines());
     }
 

--- a/tests/GitElephant/Objects/LogTest.php
+++ b/tests/GitElephant/Objects/LogTest.php
@@ -45,43 +45,43 @@ class LogTest extends TestCase
         $log = $this->getRepository()->getLog(null, null, null);
         $this->assertEquals(50, $log->count());
 
-        $log = $this->getRepository()->getLog(null, 10, null);
+        $log = $this->getRepository()->getLog(null, null, 10, null);
         $this->assertEquals(10, $log->count());
 
-        $log = $this->getRepository()->getLog(null, 50, null);
+        $log = $this->getRepository()->getLog(null, null, 50, null);
         $this->assertEquals(50, $log->count());
 
-        $log = $this->getRepository()->getLog(null, 60, null);
+        $log = $this->getRepository()->getLog(null, null, 60, null);
         $this->assertEquals(50, $log->count());
 
-        $log = $this->getRepository()->getLog(null, 1, null);
+        $log = $this->getRepository()->getLog(null, null, 1, null);
         $this->assertEquals(1, $log->count());
 
-        $log = $this->getRepository()->getLog(null, 0, null);
+        $log = $this->getRepository()->getLog(null, null, 0, null);
         $this->assertEquals(0, $log->count());
 
-        $log = $this->getRepository()->getLog(null, -1, null);
+        $log = $this->getRepository()->getLog(null, null, -1, null);
         $this->assertEquals(50, $log->count());
     }
 
     public function testLogOffset()
     {
-        $log = $this->getRepository()->getLog(null, null, 0);
+        $log = $this->getRepository()->getLog(null, null, null, 0);
         $this->assertEquals(50, $log->count());
 
-        $log = $this->getRepository()->getLog(null, null, 20);
+        $log = $this->getRepository()->getLog(null, null, null, 20);
         $this->assertEquals(30, $log->count());
 
-        $log = $this->getRepository()->getLog(null, null, 50);
+        $log = $this->getRepository()->getLog(null, null, null, 50);
         $this->assertEquals(0, $log->count());
 
-        $log = $this->getRepository()->getLog(null, null, 100);
+        $log = $this->getRepository()->getLog(null, null, null, 100);
         $this->assertEquals(0, $log->count());
     }
 
     public function testLogIndex()
     {
-        $log = $this->getRepository()->getLog(null, null, null);
+        $log = $this->getRepository()->getLog(null, null, null, null);
 
         // [0;50[ - 10 = 39
         $this->assertEquals('test commit index:39', $log[10]->getMessage()->toString());


### PR DESCRIPTION
A small change which seemed reasonable...breaks the API though...
