### PR TITLE
allow string refs in CatFileCommand

### DIFF
--- a/src/GitElephant/Command/CatFileCommand.php
+++ b/src/GitElephant/Command/CatFileCommand.php
@@ -34,18 +34,24 @@ class CatFileCommand extends BaseCommand
     /**
      * command to show content of a TreeObject at a given Treeish point
      *
-     * @param \GitElephant\Objects\TreeObject       $object  a TreeObject instance
-     * @param \GitElephant\Objects\TreeishInterface $treeish an object with TreeishInterface interface
+     * @param \GitElephant\Objects\TreeObject              $object  a TreeObject instance
+     * @param \GitElephant\Objects\TreeishInterface|string $treeish an object with TreeishInterface interface
      *
      * @return string
      */
-    public function content(TreeObject $object, TreeishInterface $treeish)
+    public function content(TreeObject $object, $treeish)
     {
+        if ($treeish instanceof TreeishInterface) {
+            $sha = $treeish->getSha();
+        } else {
+            $sha = $treeish;
+        }
+
         $this->clearAll();
         $this->addCommandName(static::GIT_CAT_FILE);
         // pretty format
         $this->addCommandArgument('-p');
-        $this->addCommandSubject($treeish->getSha() . ':' . $object->getPath());
+        $this->addCommandSubject($sha . ':' . $object->getPath());
         return $this->getCommand();
     }
 

--- a/src/GitElephant/Repository.php
+++ b/src/GitElephant/Repository.php
@@ -437,13 +437,13 @@ class Repository
     /**
      * output a node content
      *
-     * @param \GitElephant\Objects\TreeObject       $obj     The TreeObject of type BLOB
-     * @param \GitElephant\Objects\TreeishInterface $treeish A treeish object
+     * @param \GitElephant\Objects\TreeObject              $obj     The TreeObject of type BLOB
+     * @param \GitElephant\Objects\TreeishInterface|string $treeish A treeish object
      *
      * @return string
      * @throws \InvalidArgumentException
      */
-    public function outputContent(TreeObject $obj, TreeishInterface $treeish)
+    public function outputContent(TreeObject $obj, $treeish)
     {
         $command = $this->container->get('command.cat_file')->content($obj, $treeish);
         return $this->caller->execute($command)->getOutputLines();


### PR DESCRIPTION
Allows string refs in Repository::outputContent (e.g. for to fetch blobs directly without having to fetch the TreeishInterface first). Removes strong typing, but adds flexibility (I needed this for a repo browser).
