### PR TITLE
use more greedy author/committer regex to allow non-alnum names (e.g. a6...

### DIFF
--- a/src/GitElephant/Objects/Commit.php
+++ b/src/GitElephant/Objects/Commit.php
@@ -106,7 +106,7 @@ class Commit implements TreeishInterface
             if (preg_match('/^parent (\w+)$/', $line, $matches) > 0) {
                 $this->parents[] = $matches[1];
             }
-            if (preg_match('/^author ([\w ]+) <(.*)> (\d+) (.*)$/', $line, $matches) > 0) {
+            if (preg_match('/^author (.*) <(.*)> (\d+) (.*)$/', $line, $matches) > 0) {
                 $author = new GitAuthor();
                 $author->setName($matches[1]);
                 $author->setEmail($matches[2]);
@@ -114,7 +114,7 @@ class Commit implements TreeishInterface
                 $date = \DateTime::createFromFormat('U P', $matches[3] . ' ' . $matches[4]);
                 $this->datetimeAuthor = $date;
             }
-            if (preg_match('/^committer ([\w ]+) <(.*)> (\d+) (.*)$/', $line, $matches) > 0) {
+            if (preg_match('/^committer (.*) <(.*)> (\d+) (.*)$/', $line, $matches) > 0) {
                 $committer = new GitAuthor();
                 $committer->setName($matches[1]);
                 $committer->setEmail($matches[2]);


### PR DESCRIPTION
...df51 here)
