### PR TITLE
Implement git-remote command and 'show' and 'add' subcommands

### DIFF
--- a/src/GitElephant/Command/BaseCommand.php
+++ b/src/GitElephant/Command/BaseCommand.php
@@ -82,6 +82,16 @@ class BaseCommand
     }
 
     /**
+     * Get command name
+     * 
+     * @return string
+     */
+    protected function getCommandName()
+    {
+        return $this->commandName;
+    }
+
+    /**
      * Add a command argument
      *
      * @param string $commandArgument the command argument
@@ -89,6 +99,16 @@ class BaseCommand
     protected function addCommandArgument($commandArgument)
     {
         $this->commandArguments[] = $commandArgument;
+    }
+
+    /**
+     * Get all added command arguments
+     * 
+     * @return array
+     */
+    protected function getCommandArguments()
+    {
+        return ($this->commandArguments) ? $this->commandArguments: array();
     }
 
     /**
@@ -122,6 +142,39 @@ class BaseCommand
     }
 
     /**
+     * Normalize any valid option to its long name
+     * an provide a structure that can be more intellegently
+     * handled by other routines
+     *
+     * @param array $options       command options
+     * @param array $switchOptions list of valid options that are switch like
+     * @param array $valueOptions  list of valid options that must have a value assignment
+     *
+     * @return array Associative array of valid, normalized command options
+     */
+    public function normalizeOptions(Array $options = array(), Array $switchOptions = array(), $valueOptions = array())
+    {
+        $normalizedOptions = array();
+
+        foreach ($options as $option) {
+            if (array_key_exists($option, $switchOptions)) {
+                $normalizedOptions[$switchOptions[$option]] = $switchOptions[$option];
+            } else {
+                $parts = preg_split('/([\s=])+/', $option, 2, PREG_SPLIT_DELIM_CAPTURE);
+                if (count($parts)) {
+                    $optionName = $parts[0];
+                    if (in_array($optionName, $valueOptions)) {
+                        $value = ($parts[1] == '=') ? $option : array($parts[0], $parts[2]);
+                        $normalizedOptions[$optionName] = $value;
+                    }
+                }
+            }
+        }
+
+        return $normalizedOptions;
+    }
+
+    /**
      * Get the current command
      *
      * @return string
@@ -140,10 +193,20 @@ class BaseCommand
             $command .= ' ';
         }
         if (null !== $this->commandSubject) {
-            $command .= escapeshellarg($this->commandSubject);
+            if ($this->commandSubject instanceof SubCommandCommand) {
+                $command .= $this->commandSubject->getCommand();
+            } else {
+                $command .= escapeshellarg($this->commandSubject);
+            }
+            $command .= ' ';
         }
         if (null !== $this->commandSubject2) {
-            $command .= ' '.escapeshellarg($this->commandSubject2);
+            if ($this->commandSubject2 instanceof SubCommandCommand) {
+                $command .= $this->commandSubject2->getCommand();
+            } else {
+                $command .= escapeshellarg($this->commandSubject2);
+            }
+            $command .= ' ';
         }
         if (null !== $this->path) {
             $command .= sprintf(' -- %s', escapeshellarg($this->path));

--- a/src/GitElephant/Command/Remote/AddSubCommand.php
+++ b/src/GitElephant/Command/Remote/AddSubCommand.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * This file is part of the GitElephant package.
+ *
+ * (c) Matteo Giachino <matteog@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package GitElephant\Objects
+ *
+ * Just for fun...
+ */
+
+namespace GitElephant\Command\Remote;
+
+use GitElephant\Repository;
+use GitElephant\Command\SubCommandCommand;
+
+/**
+ * Class AddRemoteCommand
+ * 
+ * remote subcommand generator for add
+ *
+ * @package GitElephant\Objects
+ * @author  David Neimeyer <davidneimeyer@gmail.com>
+ */
+
+class AddSubCommand extends SubCommandCommand
+{
+    const GIT_REMOTE_ADD = 'add';
+    const GIT_REMOTE_ADD_OPTION_FETCH = '-f';
+    const GIT_REMOTE_ADD_OPTION_TAGS = '--tags';
+    const GIT_REMOTE_ADD_OPTION_NOTAGS = '--no-tags';
+    const GIT_REMOTE_ADD_OPTION_MIRROR = '--mirror';
+    const GIT_REMOTE_ADD_OPTION_SETHEAD = '-m';
+    const GIT_REMOTE_ADD_OPTION_TRACK = '-t';
+
+    /**
+     * Valid options for remote command that require an associated value
+     *
+     * @return array Array of all value-required options
+     */
+    public function addCmdValueOptions()
+    {
+        return array(
+            self::GIT_REMOTE_ADD_OPTION_TRACK => self::GIT_REMOTE_ADD_OPTION_TRACK,
+            self::GIT_REMOTE_ADD_OPTION_MIRROR => self::GIT_REMOTE_ADD_OPTION_MIRROR,
+            self::GIT_REMOTE_ADD_OPTION_SETHEAD => self::GIT_REMOTE_ADD_OPTION_SETHEAD,
+        );
+    }
+
+    /**
+     * switch only options for the add subcommand
+     *
+     * @return array
+     */
+    public function addCmdSwitchOptions()
+    {
+        return array(
+            self::GIT_REMOTE_ADD_OPTION_TAGS => self::GIT_REMOTE_ADD_OPTION_TAGS,
+            self::GIT_REMOTE_ADD_OPTION_NOTAGS => self::GIT_REMOTE_ADD_OPTION_NOTAGS,
+            self::GIT_REMOTE_ADD_OPTION_FETCH => self::GIT_REMOTE_ADD_OPTION_FETCH,
+        );
+    }
+
+    /**
+     * build add sub command
+     *
+     * @param unknown $name    remote name
+     * @param unknown $url     URL of remote
+     * @param unknown $options options for the add subcommand
+     *
+     * @return string
+     */
+    public function prepare($name, $url, $options = array())
+    {
+        $options = $this->normalizeOptions(
+            $options,
+            $this->addCmdSwitchOptions(),
+            $this->addCmdValueOptions()
+        );
+
+        $this->addCommandName(self::GIT_REMOTE_ADD);
+        $this->addCommandSubject($name);
+        $this->addCommandSubject($url);
+        foreach ($options as $option) {
+            $this->addCommandArgument($option);
+        }
+
+        return $this;
+    }
+}

--- a/src/GitElephant/Command/Remote/ShowSubCommand.php
+++ b/src/GitElephant/Command/Remote/ShowSubCommand.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * This file is part of the GitElephant package.
+ *
+ * (c) Matteo Giachino <matteog@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package GitElephant\Objects
+ *
+ * Just for fun...
+ */
+
+namespace GitElephant\Command\Remote;
+
+use GitElephant\Repository;
+use GitElephant\Command\SubCommandCommand;
+
+/**
+ * Class ShowRemoteCommand
+ * 
+ * remote subcommand generator for show
+ *
+ * @package GitElephant\Objects
+ * @author  David Neimeyer <davidneimeyer@gmail.com>
+ */
+
+class ShowSubCommand extends SubCommandCommand
+{
+    const GIT_REMOTE_SHOW = 'show';
+
+    /**
+     * build show sub command
+     *
+     * NOTE: for technical reasons $name is optional, however under normal
+     * implementation it SHOULD be passed!
+     *
+     * @param string $name
+     *
+     * @return ShowSubCommand
+     */
+    public function prepare($name = null)
+    {
+        $this->addCommandName(self::GIT_REMOTE_SHOW);
+        /**
+         *  only add subject if relevant,
+         *  otherwise on repositories without a remote defined (ie, fresh
+         *  init'd or mock) will likely trigger warning/error condition
+         *
+         */
+        if ($name) {
+            $this->addCommandSubject($name);
+        }
+
+        return $this;
+    }
+}

--- a/src/GitElephant/Command/RemoteCommand.php
+++ b/src/GitElephant/Command/RemoteCommand.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * This file is part of the GitElephant package.
+ *
+ * (c) Matteo Giachino <matteog@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package GitElephant\Objects
+ *
+ * Just for fun...
+ */
+
+namespace GitElephant\Command;
+
+use GitElephant\Repository;
+use GitElephant\Command\BaseCommand;
+use GitElephant\Command\Remote\AddSubCommand;
+use GitElephant\Command\Remote\ShowSubCommand;
+
+/**
+ * Class RemoteCommand
+ * 
+ * remote command generator
+ *
+ * @package GitElephant\Objects
+ * @author  David Neimeyer <davidneimeyer@gmail.com>
+ */
+
+class RemoteCommand extends BaseCommand
+{
+    const GIT_REMOTE = 'remote';
+    const GIT_REMOTE_OPTION_VERBOSE = '--verbose';
+    const GIT_REMOTE_OPTION_VERBOSE_SHORT = '-v';
+
+    /**
+     * Fetch an instance of RemoteCommand object
+     * 
+     * @param \GitElephant\Repository $repository Optional repository object to inject
+     * 
+     * @return RemoteCommand
+     */
+    public static function getInstance(Repository $repository = null)
+    {
+        return new self();
+    }
+
+    /**
+     * Build the remote command
+     * 
+     * NOTE: git-remote is most useful when using its subcommands, therefore
+     * in practice you will likely pass a SubCommandCommand object. This
+     * class provide "convenience" methods that do this for you.
+     * 
+     * @param \GitElephant\SubCommandCommand $subcommand A subcommand object
+     * @param array                          $options    Options for the main git-remote command
+     * 
+     * @return string Command string to pass to caller
+     */
+    public function remote(SubCommandCommand $subcommand = null, Array $options = array())
+    {
+        $normalizedOptions = $this->normalizeOptions($options, $this->remoteCmdSwitchOptions());
+
+        $this->clearAll();
+
+        $this->addCommandName(self::GIT_REMOTE);
+
+        foreach ($normalizedOptions as $key => $value) {
+            $this->addCommandArgument($value);
+        }
+
+        if ($subcommand) {
+            $this->addCommandSubject($subcommand);
+        }
+
+        return $this->getCommand();
+    }
+
+    /**
+     * Valid options for remote command that do not require an associated value
+     * 
+     * @return array Associative array mapping all non-value options and their respective normalized option
+     */
+    public function remoteCmdSwitchOptions()
+    {
+        return array(
+            self::GIT_REMOTE_OPTION_VERBOSE => self::GIT_REMOTE_OPTION_VERBOSE,
+            self::GIT_REMOTE_OPTION_VERBOSE_SHORT => self::GIT_REMOTE_OPTION_VERBOSE,
+        );
+    }
+
+    /**
+     * git-remote --verbose command
+     * 
+     * @return string
+     */
+    public function verbose()
+    {
+        return $this->remote(null, array(self::GIT_REMOTE_OPTION_VERBOSE));
+    }
+
+    /**
+     * git-remote show [name] command
+     * 
+     * NOTE: for technical reasons $name is optional, however under normal
+     * implementation it SHOULD be passed!
+     * 
+     * @param string $name
+     * 
+     * @return string
+     */
+    public function show($name = null)
+    {
+        $subcmd = new ShowSubCommand();
+        $subcmd->prepare($name);
+
+        return $this->remote($subcmd);
+    }
+
+    /**
+     * git-remote add [options] <name> <url>
+     * 
+     * @param unknown $name    remote name
+     * @param unknown $url     URL of remote
+     * @param unknown $options options for the add subcommand
+     * 
+     * @return string
+     */
+    public function add($name, $url, $options = array())
+    {
+        $subcmd = new AddSubCommand();
+        $subcmd->prepare($name, $url, $options);
+
+        return $this->remote($subcmd);
+    }
+}

--- a/src/GitElephant/Command/SubCommandCommand.php
+++ b/src/GitElephant/Command/SubCommandCommand.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * This file is part of the GitElephant package.
+ *
+ * (c) Matteo Giachino <matteog@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package GitElephant\Command
+ *
+ * Just for fun...
+ */
+
+namespace GitElephant\Command;
+
+/**
+ * SubCommandCommand
+ *
+ * A base class that can handle subcommand parameters ordering, which differes
+ * for a general command
+ *
+ * @package GitElephant\Command
+ * @author  David Neimeyer <davidneimeyer@gmail.com>
+ */
+
+class SubCommandCommand extends BaseCommand
+{
+
+    /**
+     * Subjects to a subcommand name 
+     */
+    private $orderedSubjects = array();
+
+    /**
+     * Clear all previuos variables
+     */
+    public function clearAll()
+    {
+        parent::clearAll();
+        $this->orderedSubjects = null;
+    }
+
+    protected function addCommandSubject($subject)
+    {
+        $this->orderedSubjects[] = $subject;
+    }
+
+    protected function getCommandSubjects()
+    {
+        return ($this->orderedSubjects) ? $this->orderedSubjects : array();
+    }
+
+    protected function extractArguments($args)
+    {
+        $orderArgs = array();
+        foreach ($args as $arg) {
+            if (is_array($arg)) {
+                foreach ($arg as $value) {
+                    if (!is_null($value)) {
+                        $orderArgs[] = escapeshellarg($value);
+                    }
+                }
+            } else {
+                $orderArgs[] = escapeshellarg($arg);
+            }
+        }
+
+        return implode(' ', $orderArgs);
+    }
+
+    /**
+     * Get the sub command
+     *
+     * @return string
+     * @throws \RuntimeException
+     */
+    public function getCommand()
+    {
+        $command = $this->getCommandName();
+
+        if ($command == null) {
+            throw new \RuntimeException("commandName must be specified to build a subcommand");
+        }
+
+        $command .= ' ';
+        $args = $this->getCommandArguments();
+        if (count($args) > 0) {
+            $command .= $this->extractArguments($args);
+            $command .= ' ';
+        }
+        $subjects = $this->getCommandSubjects();
+        if (count($subjects) > 0) {
+            $command .= implode(' ', array_map('escapeshellarg', $subjects));
+        }
+        $command = preg_replace('/\\s{2,}/', ' ', $command);
+
+        return trim($command);
+    }
+}
+

--- a/src/GitElephant/Objects/Remote.php
+++ b/src/GitElephant/Objects/Remote.php
@@ -1,0 +1,457 @@
+<?php
+/**
+ * This file is part of the GitElephant package.
+ *
+ * (c) Matteo Giachino <matteog@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package GitElephant\Objects
+ *
+ * Just for fun...
+ */
+
+namespace GitElephant\Objects;
+
+use GitElephant\Command\RemoteCommand;
+use GitElephant\Repository;
+
+/**
+ * Class Remote
+ * 
+ * An object representing a git remote
+ *
+ * @package GitElephant\Objects
+ * @author  David Neimeyer <davidneimeyer@gmail.com>
+ */
+
+class Remote
+{
+    /**
+     * @var \GitElephant\Repository
+     */
+    private $repository;
+
+    /**
+     * remote name
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * fetch url of named remote
+     * @var string
+     */
+    private $fetchURL = '';
+
+    /**
+     * push url of named remote
+     * @var string
+     */
+    private $pushURL = '';
+
+    /**
+     * HEAD branch of named remote
+     * @var string
+     */
+    private $remoteHEAD = null;
+
+    /**
+     * Class constructor
+     *
+     * @param \GitElephant\Repository $repository repository instance
+     * @param string                  $name       remote name
+     * 
+     * @return \GitElephant\Objects\Remote
+     */
+    public function __construct(Repository $repository, $name = null)
+    {
+        $this->repository = $repository;
+        if ($name) {
+            $this->name = trim($name);
+            $this->createFromCommand();
+        }
+
+        return $this;
+    }
+
+    /**
+     * get output lines from git-remote --verbose
+     * 
+     * @param RemoteCommand $remoteCmd Optionally provide RemoteCommand object
+     * 
+     * @return array
+     */
+    public function getVerboseOutput(RemoteCommand $remoteCmd = null)
+    {
+        if (!$remoteCmd) {
+            $remoteCmd = RemoteCommand::getInstance();
+        }
+        $command = $remoteCmd->verbose();
+
+        return $this->repository->getCaller()->execute($command)->getOutputLines(true);
+    }
+
+    /**
+     * get output lines from git-remote show [name]
+     * 
+     * NOTE: for technical reasons $name is optional, however under normal
+     * implementation it SHOULD be passed!
+     * 
+     * @param string        $name      Name of remote to show details
+     * @param RemoteCommand $remoteCmd Optionally provide RemoteCommand object
+     * 
+     * @return array
+     */
+    public function getShowOutput($name = null, RemoteCommand $remoteCmd = null)
+    {
+        if (!$remoteCmd) {
+            $remoteCmd = RemoteCommand::getInstance();
+        }
+        $command = $remoteCmd->show($name);
+
+        return $this->repository->getCaller()->execute($command)->getOutputLines(true);
+    }
+
+    /**
+     * get/store the properties from git-remote command
+     * 
+     * NOTE: the name property should be set if this is to do anything,
+     * otherwise it's likely to throw
+     *
+     * @throws \InvalidArgumentException
+     * 
+     * @return \GitElephant\Objects\Remote
+     */
+    private function createFromCommand()
+    {
+        $outputLines = $this->getVerboseOutput();
+        $list = array();
+        foreach ($outputLines as $line) {
+            $matches = static::getMatches($line);
+            if (isset($matches[1])) {
+                $list[] = $matches[1];
+            }
+        }
+        array_filter($list);
+        if (in_array($this->name, $list)) {
+            $remoteDetails = $this->getShowOutput($this->name);
+            $this->parseOutputLines($remoteDetails);
+        } else {
+            throw new \InvalidArgumentException(sprintf('The %s remote doesn\'t exists', $this->name));
+        }
+
+        return $this;
+    }
+
+    /**
+     * parse details from remote show
+     *
+     * @param string $remoteDetails Output lines for a remote show
+     */
+    public function parseOutputLines(Array $remoteDetails)
+    {
+        array_filter($remoteDetails);
+        $name = array_shift($remoteDetails);
+        $name = (is_string($name)) ? trim($name) : '';
+        $name = $this->parseName($name);
+        if (!$name) {
+            throw new \UnexpectedValueException(sprintf('Invalid data provided for remote detail parsing'));
+        }
+        $this->name = $name;
+        $fetchURLpattern = '/^Fetch\s+URL:\s*(.*)$/';
+        $fetchURL = null;
+
+        $pushURLpattern = '/^Push\s+URL:\s*(.*)$/';
+        $pushURL = null;
+
+        $remoteHEADpattern = '/^HEAD\s+branch:\s*(.*)$/';
+        $remoteHEAD = null;
+
+        $remoteBranchHeaderpattern = '/^Remote\s+branch(?:es)?:$/';
+        $localBranchPullHeaderpattern = '/^Local\sbranch(?:es)?\sconfigured\sfor\s\'git\spull\'\:$/';
+        $localRefPushHeaderpattern = '/^Local\sref(?:s)?\sconfigured\sfor\s\'git\spush\':$/';
+        $groups = array(
+            'remoteBranches'=>null,
+            'localBranches'=>null,
+            'localRefs'=>null,
+        );
+
+        foreach ($remoteDetails as $lineno => $line) {
+            $line = trim($line);
+            $matches = array();
+            if (is_null($fetchURL) && preg_match($fetchURLpattern, $line, $matches)) {
+                $this->fetchURL = $fetchURL = $matches[1];
+            } elseif (is_null($pushURL) && preg_match($pushURLpattern, $line, $matches)) {
+                $this->pushURL = $pushURL = $matches[1];
+            } elseif (is_null($remoteHEAD) && preg_match($remoteHEADpattern, $line, $matches)) {
+                $this->remoteHEAD = $remoteHEAD = $matches[1];
+            } elseif (is_null($groups['remoteBranches']) && preg_match($remoteBranchHeaderpattern, $line, $matches)) {
+                $groups['remoteBranches'] = $lineno;
+            } elseif (is_null($groups['localBranches']) && preg_match($localBranchPullHeaderpattern, $line, $matches)) {
+                $groups['localBranches'] = $lineno;
+            } elseif (is_null($groups['localRefs']) && preg_match($localRefPushHeaderpattern, $line, $matches)) {
+                $groups['localRefs'] = $lineno;
+            }
+        }
+
+        $this->setBranches($this->aggregateBranchDetails($groups, $remoteDetails));
+    }
+
+    /**
+     * provided with the start points of the branch details, parse out the
+     * branch details and return a structured representation of said details
+     * 
+     * @param array $groupLines    Associative array whose values are line numbers
+     * are respective of the "group" detail present in $remoteDetails 
+     * @param array $remoteDetails Output of git-remote show [name]
+     * 
+     * @return array
+     */
+    protected function aggregateBranchDetails($groupLines, $remoteDetails)
+    {
+        $configuredRefs = array();
+        arsort($groupLines);
+        foreach ($groupLines as $type => $lineno) {
+            $configuredRefs[$type] = array_splice($remoteDetails, $lineno);
+            array_shift($configuredRefs[$type]);
+        }
+        $configuredRefs['remoteBranches'] = (isset($configuredRefs['remoteBranches'])) ? $this->parseRemoteBranches($configuredRefs['remoteBranches']) : array();
+        $configuredRefs['localBranches'] = (isset($configuredRefs['localBranches'])) ? $this->parseLocalPullBranches($configuredRefs['localBranches']) : array();
+        $configuredRefs['localRefs'] = (isset($configuredRefs['localRefs'])) ? $this->parseLocalPushRefs($configuredRefs['localRefs']) : array();
+        $aggBranches = array();
+        foreach ($configuredRefs as $grouping => $branches) {
+            foreach ($branches as $branchName => $data) {
+                if (!isset($aggBranches[$branchName])) {
+                    $aggBranches[$branchName] = array();
+                }
+                $aggBranches[$branchName] = $aggBranches[$branchName] + $data;
+            }
+        }
+
+        return $aggBranches;
+    }
+
+    /**
+     * parse the details related to remote branch references
+     * 
+     * @param array $lines
+     * 
+     * @return array
+     */
+    public function parseRemoteBranches($lines)
+    {
+        $branches = array();
+        $delimiter = ' ';
+        foreach ($lines as $line) {
+            $line = trim($line);
+            $line = preg_replace('/\s+/', ' ', $line);
+            $parts = explode($delimiter, $line);
+            if (count($parts) > 1) {
+                $branches[$parts[0]] = array( 'local_relationship' => $parts[1]);
+            }
+        }
+
+        return $branches;
+    }
+
+    /**
+     * parse the details related to local branches and the remotes that they
+     * merge with
+     * 
+     * @param array $lines
+     * 
+     * @return array
+     */
+    public function parseLocalPullBranches($lines)
+    {
+        $branches = array();
+        $delimiter = ' merges with remote ';
+        foreach ($lines as $line) {
+            $line = trim($line);
+            $line = preg_replace('/\s+/', ' ', $line);
+            $parts = explode($delimiter, $line);
+            if (count($parts) > 1) {
+                $branches[$parts[0]] = array('merges_with' => $parts[1]);
+            }
+        }
+
+        return $branches;
+    }
+
+    /**
+     * parse the details related to local branches and the remotes that they
+     * push to
+     *
+     * @param array $lines
+     *
+     * @return array
+     */
+    public function parseLocalPushRefs($lines)
+    {
+        $branches = array();
+        $delimiter = ' pushes to ';
+        foreach ($lines as $line) {
+            $line = trim($line);
+            $line = preg_replace('/\s+/', ' ', $line);
+            $parts = explode($delimiter, $line);
+            if (count($parts) > 1) {
+                $value = explode(' ', $parts[1], 2);
+                $branches[$parts[0]] = array( 'pushes_to' => $value[0], 'local_state' => $value[1]);
+            }
+        }
+
+        return $branches;
+    }
+
+    /**
+     * parse remote name from git-remote show [name] output line
+     *  
+     * @param string $line
+     * 
+     * @return string remote name or blank if invalid
+     */
+    public function parseName($line)
+    {
+        $matches = array();
+        $pattern = '/^\*\s+remote\s+(.*)$/';
+        $result = preg_match($pattern, trim($line), $matches);
+        if (!isset($matches[1])) {
+            return '';
+        }
+
+        return $matches[1];
+    }
+
+    /**
+     * get the matches from an output line
+     *
+     * @param string $remoteString remote line output
+     *
+     * @throws \InvalidArgumentException
+     * @return array
+     */
+    public static function getMatches($remoteString)
+    {
+        $matches = array();
+        preg_match('/^(\S+)\s*(\S[^\( ]+)\s*\((.+)\)$/', trim($remoteString), $matches);
+        if (!count($matches)) {
+            throw new \InvalidArgumentException(sprintf('the remote string is not valid: %s', $remoteString));
+        }
+
+        return array_map('trim', $matches);
+    }
+
+    /**
+     * toString magic method
+     *
+     * @return string the named remote
+     */
+    public function __toString()
+    {
+        return $this->getName();
+    }
+
+    /**
+     * name setter
+     *
+     * @param string $name the remote name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * name getter
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * fetchURL getter
+     *
+     * @return string
+     */
+    public function getFetchURL()
+    {
+        return $this->fetchURL;
+    }
+
+    /**
+     * fetchURL setter
+     *
+     * @param string $url the fetch url
+     */
+    public function setFetchURL($url)
+    {
+        $this->fetchURL = $url;
+    }
+
+    /**
+     * pushURL getter
+     *
+     * @return string
+     */
+    public function getPushURL()
+    {
+        return $this->pushURL;
+    }
+
+    /**
+     * pushURL setter
+     *
+     * @param string $url the push url
+     */
+    public function setPushURL($url)
+    {
+        $this->pushURL = $url;
+    }
+
+    /**
+     * remote HEAD branch getter
+     *
+     * @return string
+     */
+    public function getRemoteHEAD()
+    {
+        return $this->remoteHEAD;
+    }
+
+    /**
+     * remote HEAD branch setter
+     *
+     * @param string $branchName
+     */
+    public function setRemoteHEAD($branchName)
+    {
+        $this->remoteHEAD = $branchName;
+    }
+
+    /**
+     * get structured representation of branches
+     * 
+     * @return array
+     */
+    public function getBranches()
+    {
+        return $this->branches;
+    }
+
+    /**
+     * set structured representation of branches
+     * 
+     * @param array $branches
+     */
+    public function setBranches(Array $branches)
+    {
+        $this->branches = $branches;
+    }
+}
+

--- a/tests/GitElephant/Command/RemoteCommandTest.php
+++ b/tests/GitElephant/Command/RemoteCommandTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * This file is part of the GitElephant package.
+ *
+ * (c) Matteo Giachino <matteog@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Just for fun...
+ */
+
+namespace GitElephant\Command;
+
+use GitElephant\TestCase;
+
+/**
+ * Class RemoteCommandTest
+ *
+ * @package GitElephant\Command
+ * @author  David Neimeyer <davidneimeyer@gmail.com>
+ */
+class RemoteCommandTest extends TestCase
+{
+    protected $startBranchName = 'test_branch';
+    protected $startTagName = 'test_start_tag';
+
+    /**
+     * setUp
+     */
+    public function setUp()
+    {
+        $this->initRepository();
+        $repo = $this->getRepository();
+        $repo->init();
+        $this->addFile('test');
+        $repo->commit('test', true);
+        $repo->createTag($this->startTagName);
+        $repo->createBranch($this->startBranchName);
+        $repo->checkout($this->startBranchName);
+    }
+
+    /**
+     * Validate generated command when no arguements and no repository are used
+     */
+    public function testRemoteNoArgs()
+    {
+        $actual = RemoteCommand::getInstance()->remote();
+        $expected = "remote";
+        $this->assertEquals($expected, $actual, 'remote() without arguments is just the remote command');
+    }
+
+    /**
+     * validate git-remote show [name]
+     */
+    public function testShow()
+    {
+        $remotename = 'foobar';
+        $actual = RemoteCommand::getInstance()->show($remotename);
+        $expected = "remote show '$remotename'";
+        $this->assertEquals($expected, $actual, 'show() builds remote command with show subcommand');
+    }
+
+    /**
+     * validate git-remote --vervose
+     */
+    public function testVerbose()
+    {
+        $actual = RemoteCommand::getInstance()->verbose();
+        $expected = "remote '--verbose'";
+        $this->assertEquals($expected, $actual, 'show() builds remote command with show subcommand');
+    }
+
+    /**
+     * validate git-remote add [options] <name> <url>
+     */
+    public function testAdd()
+    {
+        $name = 'foobar';
+        $url = 'git@foobar.com:/Foo/Bar.git';
+        $options = array(
+            '-t bazblurg',
+            '--mirror=fetch',
+            '--tags'
+        );
+        $actual = RemoteCommand::getInstance()->add($name, $url, $options);
+        $expected = "remote add '-t' 'bazblurg' '--mirror=fetch' '--tags' '$name' '$url'";
+        $this->assertEquals($expected, $actual, 'add() builds remote command with add subcommand');
+    }
+}

--- a/tests/GitElephant/Command/SubCommandCommandTest.php
+++ b/tests/GitElephant/Command/SubCommandCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This file is part of the GitElephant package.
+ *
+ * (c) Matteo Giachino <matteog@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Just for fun...
+ */
+
+namespace GitElephant\Command;
+
+use GitElephant\TestCase;
+
+/**
+ * Class RemoteCommandTest
+ *
+ * @package GitElephant\Command
+ * @author  David Neimeyer <davidneimeyer@gmail.com>
+ */
+class SubCommandCommandTest extends TestCase
+{
+    /**
+     * verify SubCommandCommands behavior, which is slightly
+     * different that BaseCommand, for more sophisticated needs
+     */
+    public function testGetCommand()
+    {
+        $cmdName = 'foo';
+        $subOne = 'bar';
+        $subTwo = 'baz';
+        $subThree = 'blurg';
+        $argOne = '--opt1';
+        $argTwo = '--opt2';
+        $argTwoValue = 'val2';
+        $expected = "foo '$argOne' '$argTwo' '$argTwoValue' '$subOne' '$subTwo' '$subThree'";
+
+        $subcmd = new SubCommandCommand();
+
+        $rmeth = new \ReflectionMethod($subcmd, 'addCommandName');
+        $rmeth->setAccessible(true);
+        $rmeth->invoke($subcmd, $cmdName);
+
+        $rmeth = new \ReflectionMethod($subcmd, 'addCommandSubject');
+        $rmeth->setAccessible(true);
+        $rmeth->invoke($subcmd, $subOne);
+
+        $rmeth = new \ReflectionMethod($subcmd, 'addCommandSubject');
+        $rmeth->setAccessible(true);
+        $rmeth->invoke($subcmd, $subTwo);
+
+        $rmeth = new \ReflectionMethod($subcmd, 'addCommandSubject');
+        $rmeth->setAccessible(true);
+        $rmeth->invoke($subcmd, $subThree);
+
+        $rmeth = new \ReflectionMethod($subcmd, 'addCommandArgument');
+        $rmeth->setAccessible(true);
+        $rmeth->invoke($subcmd, $argOne);
+
+        $rmeth = new \ReflectionMethod($subcmd, 'addCommandArgument');
+        $rmeth->setAccessible(true);
+        $rmeth->invoke($subcmd, array($argTwo, $argTwoValue));
+
+        $actual = $subcmd->getCommand();
+        $this->assertEquals($expected, $actual, 'getCommand() produces string made from subject stact and extracted args');
+    }
+}

--- a/tests/GitElephant/Objects/RemoteTest.php
+++ b/tests/GitElephant/Objects/RemoteTest.php
@@ -1,0 +1,400 @@
+<?php
+/**
+ * This file is part of the GitElephant package.
+ *
+ * (c) Matteo Giachino <matteog@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Just for fun...
+ */
+
+namespace GitElephant\Objects;
+
+use GitElephant\TestCase;
+use GitElephant\Objects\Remote;
+
+/**
+ * Class RemoteTest
+ * 
+ * Remote Object Test
+ * 
+ * @package GitElephant\Command
+ * @author  David Neimeyer <davidneimeyer@gmail.com>
+ */
+class RemoteTest extends TestCase
+{
+    /**
+     * test double branch name
+     * @var string
+     */
+    protected $startBranchName = 'test_branch';
+
+    /**
+     * test double tag name
+     * @var string
+     */
+    protected $startTagName = 'test_start_tag';
+
+    /**
+     * test setup
+     */
+    public function setUp()
+    {
+        $this->initRepository();
+        $repo = $this->getRepository();
+        $repo->init();
+        $this->addFile('test');
+        $repo->commit('test', true);
+        $repo->createTag($this->startTagName);
+        $repo->createBranch($this->startBranchName);
+        $repo->checkout($this->startBranchName);
+    }
+
+    /**
+     * return sample output of git-remote --verbose
+     * @return string
+     */
+    public function sampleRemoteVerbose()
+    {
+        $name = $this->sampleRemoteShowRemoteName();
+        $fetch = $this->sampleRemoteShowFetchURL();
+        $push = $this->sampleRemoteShowPushURL();
+
+        return <<<EOM
+origin	originFoo (fetch)
+origin	originBar (push)
+{$name}	{$fetch} (fetch)
+{$name}	{$push} (push)
+EOM;
+    }
+
+    /**
+     * test double fetch URL
+     * @return string
+     */
+    public function sampleRemoteShowFetchURL()
+    {
+        return 'git@foobar.baz:blurg/burpfetch.git';
+    }
+
+    /**
+     * test double push URL
+     * @return string
+     */
+    public function sampleRemoteShowPushURL()
+    {
+        return 'git@foobar.baz:blurg/burppush.git';
+    }
+
+    /**
+     * test double remote name
+     * @return string
+     */
+    public function sampleRemoteShowRemoteName()
+    {
+        return 'delphi';
+    }
+
+    /**
+     * test double remote HEAD branch
+     * @return string
+     */
+    public function sampleRemoteShowRemoteHEAD()
+    {
+        'Apollo';
+    }
+
+    /**
+     * sample output of git-remote show <remoteName> 
+     * @return string
+     */
+    public function sampleRemoteShow()
+    {
+        $name = $this->sampleRemoteShowRemoteName();
+        $fetch = $this->sampleRemoteShowFetchURL();
+        $push = $this->sampleRemoteShowPushURL();
+        $head = $this->sampleRemoteShowRemoteHEAD();
+
+        return <<<EOM
+* remote {$name}
+  Fetch URL: {$fetch}
+  Push  URL: {$push}
+  HEAD branch: {$head}
+  Remote branches:
+    11.30.6                                        tracked
+    11.32                                          tracked
+    11.32.0                                        tracked
+    11.40                                          tracked
+    master                                         tracked
+    pbi_4371                                       tracked
+    refs/remotes/upstream/58120-squashed           stale (use 'git remote prune' to remove)
+  Local branches configured for 'git pull':
+    11.30.6 merges with remote 11.30.6
+    11.32.0 merges with remote 11.32.0
+    11.40   merges with remote 11.40
+    master  merges with remote master
+  Local refs configured for 'git push':
+    11.30   pushes to 11.30   (local out of date)
+    11.30.6 pushes to 11.30.6 (up to date)
+    11.32   pushes to 11.32   (local out of date)
+    11.32.0 pushes to 11.32.0 (up to date)
+    11.40   pushes to 11.40   (local out of date)
+    master  pushes to master  (up to date)
+EOM;
+    }
+
+    /**
+     * expected branch structure produced when
+     * parsing the sample output of git-remote show <remoteName>
+     * @return array
+     */
+    public function sampleRemoteShowAsArray()
+    {
+        return array(
+                '11.30' => array(
+                        'pushes_to' => '11.30',
+                        'local_state' => '(local out of date)',
+                ),
+                '11.30.6' => array(
+                        'pushes_to' => '11.30.6',
+                        'local_state' => '(up to date)',
+                        'merges_with' => '11.30.6',
+                        'local_relationship' => 'tracked',
+                ),
+                '11.32.0' => array(
+                        'pushes_to' => '11.32.0',
+                        'local_state' => '(up to date)',
+                        'merges_with' => '11.32.0',
+                        'local_relationship' => 'tracked',
+                ),
+                '11.32' => array(
+                        'pushes_to' => '11.32',
+                        'local_state' => '(local out of date)',
+                        'local_relationship' => 'tracked',
+                ),
+                '11.40' => array(
+                        'pushes_to' => '11.40',
+                        'merges_with' => '11.40',
+                        'local_state' => '(local out of date)',
+                        'local_relationship' => 'tracked',
+                ),
+                'master' => array(
+                        'pushes_to' => 'master',
+                        'local_state' => '(up to date)',
+                        'merges_with' => 'master',
+                        'local_relationship' => 'tracked',
+                ),
+                'pbi_4371' => array(
+                        'local_relationship' => 'tracked',
+                ),
+                'refs/remotes/upstream/58120-squashed' => array(
+                        'local_relationship' => 'stale',
+                ),
+        );
+    }
+
+    /**
+     * test name getter
+     */
+    public function testGetName()
+    {
+        $sample = $this->sampleRemoteShow();
+        $output = explode("\n", $sample);
+        $remote = new Remote($this->getRepository());
+        $remote->parseOutputLines($output);
+        $actual = $remote->getName();
+        $expected = $this->sampleRemoteShowRemoteName();
+        $this->assertEquals($expected, $actual, 'parseOutputLines() proper digests git-remote show <remote> name');
+    }
+
+    /**
+     * test name setter
+     */
+    public function testSetName()
+    {
+        $expected = 'foobar';
+        $remote = new Remote($this->getRepository());
+        $remote->setName($expected);
+        $actual = $remote->getName();
+        $this->assertEquals($expected, $actual, 'can set remote name');
+    }
+
+    /**
+     * test fetch URL getter
+     */
+    public function testGetFetchURL()
+    {
+        $sample = $this->sampleRemoteShow();
+        $output = explode("\n", $sample);
+        $remote = new Remote($this->getRepository());
+        $remote->parseOutputLines($output);
+        $actual = $remote->getFetchURL();
+        $expected = $this->sampleRemoteShowFetchURL();
+        $this->assertEquals($expected, $actual, 'parseOutputLines() proper digests git-remote show <remote> fetch URL');
+    }
+
+    /**
+     * test fetch URL setter
+     */
+    public function testSetFetchURL()
+    {
+        $expected = 'foobar';
+        $remote = new Remote($this->getRepository());
+        $remote->setFetchURL($expected);
+        $actual = $remote->getFetchURL();
+        $this->assertEquals($expected, $actual, 'can set fetch URL property');
+    }
+
+    /**
+     * test push URL getter
+     */
+    public function testGetPushURL()
+    {
+        $sample = $this->sampleRemoteShow();
+        $output = explode("\n", $sample);
+        $remote = new Remote($this->getRepository());
+        $remote->parseOutputLines($output);
+        $actual = $remote->getPushURL();
+        $expected = $this->sampleRemoteShowPushURL();
+        $this->assertEquals($expected, $actual, 'parseOutputLines() proper digests git-remote show <remote> push URL');
+    }
+
+    /**
+     * test push URL setter
+     */
+    public function testSetPushURL()
+    {
+        $expected = 'foobar';
+        $remote = new Remote($this->getRepository());
+        $remote->setPushURL($expected);
+        $actual = $remote->getPushURL();
+        $this->assertEquals($expected, $actual, 'can set push URL property');
+    }
+
+    /**
+     * test remote HEAD branch getter
+     */
+    public function testGetRemoteHEAD()
+    {
+        $sample = $this->sampleRemoteShow();
+        $output = explode("\n", $sample);
+        $remote = new Remote($this->getRepository());
+        $remote->parseOutputLines($output);
+        $actual = $remote->getRemoteHEAD();
+        $expected = $this->sampleRemoteShowRemoteHEAD();
+        $this->assertEquals($expected, $actual, 'parseOutputLines() proper digests git-remote show <remote> remote HEAD');
+    }
+
+    /**
+     * test remote HEAD branch setter
+     */
+    public function testSetRemoteHEAD()
+    {
+        $expected = 'foobar';
+        $remote = new Remote($this->getRepository());
+        $remote->setRemoteHEAD($expected);
+        $actual = $remote->getRemoteHEAD();
+        $this->assertEquals($expected, $actual, 'can set remote HEAD property');
+    }
+
+    /**
+     * test branch detail parsing
+     */
+    public function testParseOutputLines()
+    {
+        $sample = $this->sampleRemoteShow();
+        $output = explode("\n", $sample);
+        $remote = new Remote($this->getRepository());
+        $remote->parseOutputLines($output);
+        $actual = $remote->getBranches();
+        $expected = $this->sampleRemoteShowAsArray();
+        $this->assertEquals($expected, $actual, 'parseOutputLines() proper digests git-remote show <remote> branch references');
+    }
+
+    /**
+     * helper for getting a mock Remote object
+     * 
+     * the returned test double will provide the sample output
+     * defined in other methods of this test class
+     * 
+     * NOTE: this will do an assertion in the hope to ensure
+     * sanity of the test double
+     * 
+     * @return \GitElephant\Objects\Remote
+     */
+    public function getMockRemote()
+    {
+        $sample = $this->sampleRemoteShow();
+        $showOutput = explode("\n", $sample);
+        $sample = $this->sampleRemoteVerbose();
+        $verboseOutput = explode("\n", $sample);
+
+        $mockRemote = $this->getMock(
+            '\\GitElephant\\Objects\\Remote', //class
+            array('getShowOutput', 'getVerboseOutput'), //methods to mock
+            array(), //original constructor args
+            '', //class for test double
+            false //call constructor
+        );
+
+        $mockRemote->expects($this->any())
+            ->method('getShowOutput')
+            ->will($this->returnValue($showOutput));
+        $mockRemote->expects($this->any())
+            ->method('getVerboseOutput')
+            ->will($this->returnValue($verboseOutput));
+
+        $name = $this->sampleRemoteShowRemoteName();
+        $mockRemote->__construct($this->getRepository(), $name);
+        $this->assertEquals($this->sampleRemoteShowRemoteName(), $mockRemote->getName(), 'able to create mock object with properly parsed sample data');
+
+        return $mockRemote;
+    }
+
+    /**
+     * verify object
+     * 
+     * NOTE: this is actually verifying the mock object and
+     * could be useless if the helper that makes the double
+     * is flawed.  However, it should do the trick so other tests
+     * that depend on the double will have supporting test data/failures
+     */
+    public function testConstructor()
+    {
+        $obj = $this->getMockRemote();
+        $this->assertInstanceOf('\\GitElephant\\Objects\\Remote', $obj);
+    }
+
+    /**
+     * verify name is produced with cast to a string
+     */
+    public function testToString()
+    {
+        $obj = $this->getMockRemote();
+        $this->assertEquals($this->sampleRemoteShowRemoteName(), (string) $obj, 'magic to string method provides the remote name');
+    }
+
+    /**
+     * verify that we always get an array, even if empty, when getting
+     * data from the underlying implementation
+     */
+    public function testGetVerboseOutputReturnArray()
+    {
+        $remote = new Remote($this->getRepository());
+        $actual = $remote->getVerboseOutput();
+        $this->assertTrue(is_array($actual), 'getVerboseOutput() returns array');
+    }
+
+    /**
+     * verify that we always get an array, even if empty, when getting
+     * data from the underlying implementation
+     */
+    public function testGetShowOutputReturnArray()
+    {
+        $remote = new Remote($this->getRepository());
+        $actual = $remote->getShowOutput();
+        $this->assertTrue(is_array($actual), 'getShowOutput() returns array');
+    }
+}


### PR DESCRIPTION
This changeset introduces the Remote command:

Of Note, there are also changes to BaseCommand such that it's reasonable
to do more sophisticated things in the provided Command\SubCommandCommand
class and any Command<command> class that intends on extending from this
new class.

Now, BaseCommand + SubCommandCommand introduces the concept of
passing a SubCommandCommand object to BaseCommand::addCommandSubject(),
which will be extracted to the appropriate string when
BaseCommand::getCommand() is called.

Technically speaking, SubCommandCommand wasn't a design requirment to
implement the remote command, provided some changes to BaseCommand were
made. However, having SubCommandCommand provides:
1) reasonable/minimal level of abstraction that emulates/models the git
cli more accurately.
2) provides more clarity for maintainers and implementors when building/
using subcommands.
3) provides more flexibility when constructing git cli commands which, at
times, be quirky for subcommands.
...it's debatable: maybe it should be a monolithic.

As well there's the concept of normalizing options when extending
BaseCommand such that you can:
1) validate implementer's options
2) as implementer/consumer, use the constant intead of the actually
option string argument (this puts more onus on maintainers of
GitElephant to track GIT cli, but it should be better for consumers)
3)potentially validate associated values with options in the future
