### PR TITLE
Add more info to the exception.

### DIFF
--- a/src/GitElephant/Command/Caller/Caller.php
+++ b/src/GitElephant/Command/Caller/Caller.php
@@ -104,7 +104,11 @@ class Caller implements CallerInterface
         $process->setTimeout(15000);
         $process->run();
         if (!in_array($process->getExitCode(), $acceptedExitCodes)) {
-            throw new \RuntimeException($process->getErrorOutput());
+            $text = 'Exit code: ' . $process->getExitCode();
+            $text .= ' while executing: "' . $cmd;
+            $text .= '" with reason: ' . $process->getErrorOutput();
+            $text .= "\n" . $process->getOutput();
+            throw new \RuntimeException($text);
         }
         $this->rawOutput = $process->getOutput();
         // rtrim values


### PR DESCRIPTION
Without this patch it's hard to find the reason why.

We had a hard time to finding why our commit failed.

With this patch output is something like

```
RuntimeException : Exit code: 1 while executing: "/usr/local/bin/git commit '-a' '-m' 'testGitPull-commit'" with reason: 
On branch master
nothing to commit, working directory clean
```

I also tried to inject exit code 1 into

``` php
class Caller implements CallerInterface
{
...
    public function execute($cmd, $git = true, $cwd = null, $acceptedExitCodes = array(0))
```

from

``` php
class MainCommand extends BaseCommand
{
...
    public function commit($message, $stageAll = false, $author = null)
```

but failed.
### Open issues are
- [ ] Can we add git exit code 1 to `$acceptedExitCodes` for commit?
- [ ] Is git exit code 1 allows OK to add to `$acceptedExitCodes`?
- [ ] Are there more exit codes to `$acceptedExitCodes`?
