### PR TITLE
Added listX() methods to replace uses of lists()

### DIFF
--- a/src/GitElephant/Command/BranchCommand.php
+++ b/src/GitElephant/Command/BranchCommand.php
@@ -84,7 +84,7 @@ class BranchCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string the command
      */
-    public function lists($all = false, $simple = false)
+    public function listBranches($all = false, $simple = false)
     {
         $this->clearAll();
         $this->addCommandName(self::BRANCH_COMMAND);
@@ -98,6 +98,24 @@ class BranchCommand extends BaseCommand
         }
 
         return $this->getCommand();
+    }
+
+    /**
+     * Lists branches
+     *
+     * @deprecated This method uses an unconventional name but is being left in
+     *             place to remain compatible with existing code relying on it.
+     *             New code should be written to use listBranches().
+     *
+     * @param bool $all    lists all remotes
+     * @param bool $simple list only branch names
+     *
+     * @throws \RuntimeException
+     * @return string the command
+     */
+    public function lists($all = false, $simple = false)
+    {
+        return $this->listBranches($all, $simple);
     }
 
     /**

--- a/src/GitElephant/Command/SubmoduleCommand.php
+++ b/src/GitElephant/Command/SubmoduleCommand.php
@@ -59,16 +59,31 @@ class SubmoduleCommand extends BaseCommand
     }
 
     /**
-     * Lists tags
+     * Lists submodules
+     *
+     * @throws \RuntimeException
+     * @return string the command
+     */
+    public function listSubmodules()
+    {
+        $this->clearAll();
+        $this->addCommandName(self::SUBMODULE_COMMAND);
+
+        return $this->getCommand();
+    }
+
+    /**
+     * Lists submodules
+     *
+     * @deprecated This method uses an unconventional name but is being left in
+     *             place to remain compatible with existing code relying on it.
+     *             New code should be written to use listSubmodules().
      *
      * @throws \RuntimeException
      * @return string the command
      */
     public function lists()
     {
-        $this->clearAll();
-        $this->addCommandName(self::SUBMODULE_COMMAND);
-
-        return $this->getCommand();
+        return $this->listSubmodules();
     }
 }

--- a/src/GitElephant/Command/TagCommand.php
+++ b/src/GitElephant/Command/TagCommand.php
@@ -72,12 +72,27 @@ class TagCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string the command
      */
-    public function lists()
+    public function listTags()
     {
         $this->clearAll();
         $this->addCommandName(self::TAG_COMMAND);
 
         return $this->getCommand();
+    }
+
+    /**
+     * Lists tags
+     *
+     * @deprecated This method uses an unconventional name but is being left in
+     *             place to remain compatible with existing code relying on it.
+     *             New code should be written to use listTags().
+     *
+     * @throws \RuntimeException
+     * @return string the command
+     */
+    public function lists()
+    {
+        return $this->listTags();
     }
 
     /**

--- a/src/GitElephant/Objects/Branch.php
+++ b/src/GitElephant/Objects/Branch.php
@@ -150,7 +150,7 @@ class Branch extends Object implements TreeishInterface
      */
     private function createFromCommand()
     {
-        $command = BranchCommand::getInstance()->lists();
+        $command = BranchCommand::getInstance()->listBranches();
         $outputLines = $this->repository->getCaller()->execute($command)->getOutputLines(true);
         foreach ($outputLines as $outputLine) {
             $matches = static::getMatches($outputLine);

--- a/src/GitElephant/Objects/Tag.php
+++ b/src/GitElephant/Objects/Tag.php
@@ -137,7 +137,7 @@ class Tag extends Object
      */
     private function createFromCommand()
     {
-        $command = TagCommand::getInstance()->lists();
+        $command = TagCommand::getInstance()->listTags();
         $outputLines = $this->getCaller()->execute($command, true, $this->getRepository()->getPath())->getOutputLines();
         $this->parseOutputLines($outputLines);
     }

--- a/src/GitElephant/Repository.php
+++ b/src/GitElephant/Repository.php
@@ -372,7 +372,7 @@ class Repository
     {
         $branches = array();
         if ($namesOnly) {
-            $outputLines = $this->caller->execute(BranchCommand::getInstance()->lists($all, true))->getOutputLines(
+            $outputLines = $this->caller->execute(BranchCommand::getInstance()->listBranches($all, true))->getOutputLines(
                 true
             );
             $branches = array_map(
@@ -393,7 +393,7 @@ class Repository
                 }
             };
         } else {
-            $outputLines = $this->caller->execute(BranchCommand::getInstance()->lists($all))->getOutputLines(true);
+            $outputLines = $this->caller->execute(BranchCommand::getInstance()->listBranches($all))->getOutputLines(true);
             foreach ($outputLines as $branchLine) {
                 $branches[] = Branch::createFromOutputLine($this, $branchLine);
             }
@@ -598,7 +598,7 @@ class Repository
     public function getTags()
     {
         $tags = array();
-        $this->caller->execute(TagCommand::getInstance()->lists());
+        $this->caller->execute(TagCommand::getInstance()->listTags());
         foreach ($this->caller->getOutputLines() as $tagString) {
             if ($tagString != '') {
                 $tags[] = new Tag($this, trim($tagString));
@@ -670,7 +670,7 @@ class Repository
         if (in_array($name, $this->getBranches(true))) {
             return new Branch($this, $name);
         }
-        $tagFinderOutput = $this->caller->execute(TagCommand::getInstance()->lists())->getOutputLines(true);
+        $tagFinderOutput = $this->caller->execute(TagCommand::getInstance()->listTags())->getOutputLines(true);
         foreach ($tagFinderOutput as $line) {
             if ($line === $name) {
                 return new Tag($this, $name);

--- a/tests/GitElephant/Command/BranchCommandTest.php
+++ b/tests/GitElephant/Command/BranchCommandTest.php
@@ -54,6 +54,19 @@ class BranchCommandTest extends TestCase
     }
 
     /**
+     * listBranches test
+     *
+     * @covers GitElephant\Command\BranchCommand::listBranches
+     */
+    public function testListBranches()
+    {
+        $branch = new BranchCommand();
+        $this->assertEquals($branch->listBranches(), "branch '-v' '--no-color' '--no-abbrev'");
+        $this->assertEquals($branch->listBranches(true), "branch '-v' '--no-color' '--no-abbrev' '-a'");
+        $this->assertEquals($branch->listBranches(false, true), "branch '--no-color' '--no-abbrev'");
+    }
+
+    /**
      * lists test
      *
      * @covers GitElephant\Command\BranchCommand::lists


### PR DESCRIPTION
This pull request addresses #69.

The method name lists() is highly unconventional and unintuitive, so I set out to change it on my way to adding some submodule features.  I have maintained compatibility with code that already uses the lists() methods.

I have not added new unit tests for XCommand classes that did not already have them.  My reasoning was that I am not really adding new functionality here, so the need for additional coverage is very low.
