### PR TITLE
fix tests when running phpunit on php without date.timezone set

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,3 +29,5 @@ spl_autoload_register(function ($class) {
 });
 
 echo exec('git --version')."\n";
+
+date_default_timezone_set('UTC');


### PR DESCRIPTION
This is what you get if your php configuration does not set a default timezone when running tests

```
mathieu at texthtml on GitElephant:develop ⚡ vendor/bin/phpunit
git version 1.9.3
PHPUnit 4.1.4 by Sebastian Bergmann.

Configuration read from /home/mathieu/workspaces/GitElephant/phpunit.xml

.............E

Time: 1.79 seconds, Memory: 8.75Mb

There was 1 error:

1) GitElephant\Command\DiffCommandTest::testDiff
DateTime::createFromFormat(): It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone.

/home/mathieu/workspaces/GitElephant/src/GitElephant/Objects/Commit.php:241
hp:49
/home/mathieu/workspaces/GitElephant/src/GitElephant/Objects/Commit.php:181
/home/mathieu/workspaces/GitElephant/src/GitElephant/Objects/Commit.php:151
/home/mathieu/workspaces/GitElephant/src/GitElephant/Repository.php:724
/home/mathieu/workspaces/GitElephant/tests/GitElephant/Command/DiffCommandTest.p

FAILURES!
Tests: 14, Assertions: 97, Errors: 1.
```

this PR fix this by always settings the timezone to UTC in tests/bootstrap.php
