### PR TITLE
Removing global properties from clearAll reset

### DIFF
--- a/src/GitElephant/Command/BaseCommand.php
+++ b/src/GitElephant/Command/BaseCommand.php
@@ -125,10 +125,7 @@ class BaseCommand
     {
         $this->commandName            = null;
         $this->configs                = array();
-        $this->globalConfigs          = array();
-        $this->globalOptions          = array();
         $this->commandArguments       = array();
-        $this->globalCommandArguments = array();
         $this->commandSubject         = null;
         $this->commandSubject2        = null;
         $this->path                   = null;


### PR DESCRIPTION
Which should never have been there in the first place (fixes #77)