### PR TITLE
Fixed a bug wherein the interface for submodule update

### DIFF
--- a/src/GitElephant/Repository.php
+++ b/src/GitElephant/Repository.php
@@ -643,7 +643,7 @@ class Repository
      */
     public function updateSubmodule($recursive = false, $init = false, $force = false, $path = null)
     {
-        $this->caller->execute(SubmoduleCommand::getInstance()->update($path));
+        $this->caller->execute(SubmoduleCommand::getInstance()->update($recursive, $init, $force, $path));
         return $this;
     }
 

--- a/src/GitElephant/Repository.php
+++ b/src/GitElephant/Repository.php
@@ -627,7 +627,7 @@ class Repository
      */
     public function initSubmodule($path = null)
     {
-        $this->caller->execute(SubmoduleCommand::getInstance()->init($path));
+        $this->caller->execute(SubmoduleCommand::getInstance($this)->init($path));
         return $this;
     }
 
@@ -643,7 +643,7 @@ class Repository
      */
     public function updateSubmodule($recursive = false, $init = false, $force = false, $path = null)
     {
-        $this->caller->execute(SubmoduleCommand::getInstance()->update($recursive, $init, $force, $path));
+        $this->caller->execute(SubmoduleCommand::getInstance($this)->update($recursive, $init, $force, $path));
         return $this;
     }
 


### PR DESCRIPTION
Fixed a bug wherein the interface for submodule update with --init, --force and --recursive flags was ignoring those flags.  This is an old feature I submitted that I'm only now getting around to implementing, so I wanted to share this bug fix with the project.