### PR TITLE
Moved validation of the repository directory to the Caller that is re…

### DIFF
--- a/src/GitElephant/Command/Caller/Caller.php
+++ b/src/GitElephant/Command/Caller/Caller.php
@@ -19,6 +19,7 @@
 
 namespace GitElephant\Command\Caller;
 
+use GitElephant\Exception\InvalidRepositoryPathException;
 use \GitElephant\GitBinary;
 use \Symfony\Component\Process\Process;
 
@@ -66,6 +67,11 @@ class Caller implements CallerInterface
     public function __construct(GitBinary $binary, $repositoryPath)
     {
         $this->binary         = $binary;
+
+        if (!is_dir($repositoryPath)) {
+            throw new InvalidRepositoryPathException($repositoryPath);
+        }
+
         $this->repositoryPath = $repositoryPath;
     }
 

--- a/src/GitElephant/Repository.php
+++ b/src/GitElephant/Repository.php
@@ -120,9 +120,7 @@ class Repository
         if ($binary == null) {
             $binary = new GitBinary();
         }
-        if (!is_dir($repositoryPath)) {
-            throw new InvalidRepositoryPathException($repositoryPath);
-        }
+
         $this->path = $repositoryPath;
         $this->caller = new Caller($binary, $repositoryPath);
         $this->name = $name;

--- a/tests/GitElephant/Command/CallerTest.php
+++ b/tests/GitElephant/Command/CallerTest.php
@@ -108,4 +108,13 @@ class CallerTest extends TestCase
         $caller->execute('status');
         $this->assertRegExp('/master/', $caller->getRawOutput($caller->getRawOutput()));
     }
+
+    /**
+     * @expectedException \GitElephant\Exception\InvalidRepositoryPathException
+     */
+    public function testRepositoryValidation()
+    {
+        $binary = new GitBinary();
+        $caller = new Caller($binary, 'someinvalidpath');
+    }
 }

--- a/tests/GitElephant/RepositoryTest.php
+++ b/tests/GitElephant/RepositoryTest.php
@@ -57,6 +57,10 @@ class RepositoryTest extends TestCase
     {
         $this->getRepository()->init();
         $match = false;
+
+        // Force US/EN locale
+        putenv('LANG=en_US.UTF-8');
+
         foreach ($this->getRepository()->getStatusOutput() as $line) {
             if (preg_match('/nothing to commit?(.*)/', $line)) {
                 $match = true;


### PR DESCRIPTION
…sponsible to run local Commands.

This is needed, since the validation of the directory, should not happen, when you use CallerSSH2.
CallerSSH2 is used to execute git commands on another server via ssh, checking for a valid repository makes no sense in this case.
A valiadtion of the repository should be added to the SSH Caller though.