### PR TITLE
Add option to pass arguments in to push command

### DIFF
--- a/src/GitElephant/Command/PushCommand.php
+++ b/src/GitElephant/Command/PushCommand.php
@@ -49,7 +49,7 @@ class PushCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function push($remote = 'origin', $branch = 'master')
+    public function push($remote = 'origin', $branch = 'master', $args = null)
     {
         if ($remote instanceof Remote) {
             $remote = $remote->getName();
@@ -61,6 +61,10 @@ class PushCommand extends BaseCommand
         $this->addCommandName(self::GIT_PUSH_COMMAND);
         $this->addCommandSubject($remote);
         $this->addCommandSubject2($branch);
+
+        if(!is_null($args)) {
+            $this->addCommandArgument($args);
+        }
 
         return $this->getCommand();
     }


### PR DESCRIPTION
Until I find a permanent solution where any command can have optional arguments this is a very doable solution for a common problem (not being able to push tags)