### PR TITLE
Commits can search own tags

### DIFF
--- a/src/GitElephant/Objects/Commit.php
+++ b/src/GitElephant/Objects/Commit.php
@@ -406,4 +406,42 @@ class Commit implements TreeishInterface, \Countable
 
         return array_map('trim', $caller->getOutputLines(true));
     }
+
+    /**
+     * Is the commit tagged?
+     *
+     * return true if some tag of repository point to this commit
+     * return false otherwise
+     *
+     * @return bool
+     */
+    public function tagged()
+    {
+        $result = false;
+        foreach ($this->repository->getTags() as $tag) {
+            if ($tag->getSha() == $this->getSha()) {
+                $result = true;
+                break;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Return Tags that point to this commit
+     *
+     * @return Tag[]
+     */
+    public function getTags()
+    {
+        $currentCommitTags = [];
+        foreach ($this->repository->getTags() as $tag) {
+            if ($tag->getSha() == $this->getSha()) {
+                $currentCommitTags[] = $tag;
+            }
+        }
+
+        return $currentCommitTags;
+    }
 }

--- a/src/GitElephant/Objects/Commit.php
+++ b/src/GitElephant/Objects/Commit.php
@@ -435,7 +435,7 @@ class Commit implements TreeishInterface, \Countable
      */
     public function getTags()
     {
-        $currentCommitTags = [];
+        $currentCommitTags = array();
         foreach ($this->repository->getTags() as $tag) {
             if ($tag->getSha() == $this->getSha()) {
                 $currentCommitTags[] = $tag;

--- a/tests/GitElephant/Objects/CommitTest.php
+++ b/tests/GitElephant/Objects/CommitTest.php
@@ -242,7 +242,8 @@ class CommitTest extends TestCase
         Tag::create($this->repository, '1.0.0');
         $this->assertTrue($commit->tagged());
         $this->assertCount(1, $commit->getTags());
-        $this->assertEquals('1.0.0', reset($commit->getTags())->getName());
+        $commitTags = $commit->getTags();
+        $this->assertEquals('1.0.0', $commitTags[0]->getName());
     }
 
 }

--- a/tests/GitElephant/Objects/CommitTest.php
+++ b/tests/GitElephant/Objects/CommitTest.php
@@ -242,7 +242,7 @@ class CommitTest extends TestCase
         Tag::create($this->repository, '1.0.0');
         $this->assertTrue($commit->tagged());
         $this->assertCount(1, $commit->getTags());
-        $this->assertEquals('1.0.0', $commit->getTags()[0]->getName());
+        $this->assertEquals('1.0.0', reset($commit->getTags())->getName());
     }
 
 }

--- a/tests/GitElephant/Objects/CommitTest.php
+++ b/tests/GitElephant/Objects/CommitTest.php
@@ -223,4 +223,26 @@ class CommitTest extends TestCase
         $revParse = $commit->revParse();
         $this->assertEquals($commit->getSha(), $revParse[0]);
     }
+
+    public function testCommitWithoutTag()
+    {
+        $this->getRepository()->init();
+        $this->addFile('test');
+        $this->repository->stage();
+        $commit = Commit::create($this->repository, 'first commit', true);
+        $this->assertFalse($commit->tagged());
+    }
+
+    public function testCommitWithTag()
+    {
+        $this->getRepository()->init();
+        $this->addFile('test');
+        $this->repository->stage();
+        $commit = Commit::create($this->repository, 'first commit', true);
+        Tag::create($this->repository, '1.0.0');
+        $this->assertTrue($commit->tagged());
+        $this->assertCount(1, $commit->getTags());
+        $this->assertEquals('1.0.0', $commit->getTags()[0]->getName());
+    }
+
 }


### PR DESCRIPTION
Sometimes we need to know is some tag of repository to point to certain commit or not.  I had add 2 methods to `Commit` class: `Commit::tagged()` and `Commit::getTags()`

I think right way for this functionality is create some Commit Wrapper like `TagInformedCommit` and add 2 methods to it. But this approach does not match architecture of this library. May be you can propose another way? 

Thanks a lot! You develop a really useful tool!