### PR TITLE
Fix fatal in PHP 7

### DIFF
--- a/src/GitElephant/Objects/Commit.php
+++ b/src/GitElephant/Objects/Commit.php
@@ -221,7 +221,7 @@ class Commit implements TreeishInterface, \Countable
      */
     private function parseOutputLines($outputLines)
     {
-        $message = '';
+        $message = [];
         foreach ($outputLines as $line) {
             $matches = array();
             if (preg_match('/^commit (\w+)$/', $line, $matches) > 0) {

--- a/src/GitElephant/Objects/Commit.php
+++ b/src/GitElephant/Objects/Commit.php
@@ -221,7 +221,7 @@ class Commit implements TreeishInterface, \Countable
      */
     private function parseOutputLines($outputLines)
     {
-        $message = [];
+        $message = array();
         foreach ($outputLines as $line) {
             $matches = array();
             if (preg_match('/^commit (\w+)$/', $line, $matches) > 0) {


### PR DESCRIPTION
Error: [] operator not supported for strings
because $message is string an `$message[]` is executed.