### PR TITLE
Added ability to get git binary version from within commands

### DIFF
--- a/src/GitElephant/Command/BaseCommand.php
+++ b/src/GitElephant/Command/BaseCommand.php
@@ -95,6 +95,11 @@ class BaseCommand
     private $path = null;
 
     /**
+     * @var string
+     */
+    private $binaryVersion;
+
+    /**
      * constructor
      *
      * should be called by all child classes' constructors to permit use of 
@@ -114,6 +119,7 @@ class BaseCommand
                     $this->addGlobalCommandArgument($argument);
                 }
             }
+            $this->binaryVersion = $repo->getCaller()->getBinaryVersion();
         }
     }
 
@@ -128,6 +134,7 @@ class BaseCommand
         $this->commandSubject         = null;
         $this->commandSubject2        = null;
         $this->path                   = null;
+        $this->binaryVersion          = null;
     }
 
     public static function getInstance(Repository $repo = null)
@@ -436,5 +443,13 @@ class BaseCommand
             }
         }
         return $command;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getBinaryVersion()
+    {
+        return $this->binaryVersion;
     }
 }

--- a/src/GitElephant/Command/Caller/Caller.php
+++ b/src/GitElephant/Command/Caller/Caller.php
@@ -90,13 +90,19 @@ class Caller implements CallerInterface
     }
 
     /**
-     * Get the binary path
-     *
-     * @return mixed
+     * @inheritdoc
      */
     public function getBinaryPath()
     {
         return $this->binary->getPath();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getBinaryVersion()
+    {
+        return $this->binary->getVersion();
     }
 
     /**

--- a/src/GitElephant/Command/Caller/CallerInterface.php
+++ b/src/GitElephant/Command/Caller/CallerInterface.php
@@ -43,4 +43,18 @@ interface CallerInterface
      * @return array
      */
     public function getOutputLines($stripBlankLines = false);
+
+    /**
+     * Get the binary path
+     *
+     * @return string
+     */
+    public function getBinaryPath();
+
+    /**
+     * Get the binary version
+     *
+     * @return string
+     */
+    public function getBinaryVersion();
 }

--- a/src/GitElephant/Command/Caller/CallerSSH2.php
+++ b/src/GitElephant/Command/Caller/CallerSSH2.php
@@ -37,6 +37,11 @@ class CallerSSH2 implements CallerInterface
     private $gitPath;
 
     /**
+     * @var string
+     */
+    private $binaryVersion;
+
+    /**
      * the output lines of the command
      *
      * @var array
@@ -54,6 +59,8 @@ class CallerSSH2 implements CallerInterface
     {
         $this->resource = $resource;
         $this->gitPath = $gitPath;
+        // unix only
+        $this->binaryVersion = $this->execute('--version | cut -d " " -f 3', true);
     }
 
     /**
@@ -102,5 +109,21 @@ class CallerSSH2 implements CallerInterface
         }
 
         return $this->outputLines;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getBinaryPath()
+    {
+        return $this->gitPath;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getBinaryVersion()
+    {
+        return $this->binaryVersion;
     }
 }

--- a/src/GitElephant/GitBinary.php
+++ b/src/GitElephant/GitBinary.php
@@ -35,6 +35,11 @@ class GitBinary
     private $path;
 
     /**
+     * @var string
+     */
+    private $version;
+
+    /**
      * Class constructor
      *
      * @param null $path the physical path to the git binary
@@ -52,7 +57,7 @@ class GitBinary
      * path getter
      * returns the path of the binary
      *
-     * @return mixed
+     * @return string
      */
     public function getPath()
     {
@@ -67,5 +72,19 @@ class GitBinary
     public function setPath(string $path)
     {
         $this->path = $path;
+    }
+
+    /**
+     * @return string
+     */
+    public function getVersion()
+    {
+        if (is_null($this->version)) {
+
+            // unix only!
+            $this->version = exec('git --version | cut -d " " -f 3');
+        }
+
+        return $this->version;
     }
 }

--- a/src/GitElephant/GitBinary.php
+++ b/src/GitElephant/GitBinary.php
@@ -80,9 +80,11 @@ class GitBinary
     public function getVersion()
     {
         if (is_null($this->version)) {
-
-            // unix only!
-            $this->version = exec('git --version | cut -d " " -f 3');
+            $version = exec('git --version');
+            if (!preg_match('/^git version [0-9\.]+$/', $version)) {
+                throw new \RuntimeException('Could not parse git version. Unexpected format "' . $version . '".');
+            }
+            $this->version = preg_replace('/^git version ([0-9\.]+)$/', '$1', $version);
         }
 
         return $this->version;

--- a/tests/GitElephant/Command/BaseCommandTest.php
+++ b/tests/GitElephant/Command/BaseCommandTest.php
@@ -277,4 +277,11 @@ class BaseCommandTest extends TestCase
         $actual = $ref_bc_cli_meth->invoke($bc);
         $this->assertSame($expected, $actual);
     }
+
+    public function testGetBinaryVersion()
+    {
+        $repo = $this->getRepository();
+        $bc = BaseCommand::getInstance($repo);
+        $this->assertInternalType('string', $bc->getBinaryVersion());
+    }
 }

--- a/tests/GitElephant/Command/CallerTest.php
+++ b/tests/GitElephant/Command/CallerTest.php
@@ -54,6 +54,16 @@ class CallerTest extends TestCase
     }
 
     /**
+     * testGetBinaryVersion
+     */
+    public function testGetBinaryVersion()
+    {
+        $binary = new GitBinary();
+        $c = new Caller($binary, $this->repository->getPath());
+        $this->assertInternalType('string', $c->getBinaryVersion());
+    }
+
+    /**
      * @expectedException \RuntimeException
      */
     public function testGetError()

--- a/tests/GitElephant/GitBinaryTest.php
+++ b/tests/GitElephant/GitBinaryTest.php
@@ -13,14 +13,11 @@
 
 namespace GitElephant;
 
-use \GitElephant\GitBinary;
-
 /**
  * GitBinary Test
  *
  * @author Matteo Giachino <matteog@gmail.com>
  */
-
 class GitBinaryTest extends TestCase
 {
     protected $path = '/path/to/binary';
@@ -29,5 +26,11 @@ class GitBinaryTest extends TestCase
     {
         $binary = new GitBinary($this->path);
         $this->assertEquals($this->path, $binary->getPath());
+    }
+
+    public function testGetVersion()
+    {
+        $binary = new GitBinary($this->path);
+        $this->assertInternalType('string', $binary->getVersion());
     }
 }


### PR DESCRIPTION
This is useful for gracefully supporting newer git binary functions. For example the `--branch` option of the `git clone` command is only available from 2.0.0 and up.