### PR TITLE
Added support for branch and shallow clones

### DIFF
--- a/src/GitElephant/Command/CloneCommand.php
+++ b/src/GitElephant/Command/CloneCommand.php
@@ -63,8 +63,6 @@ class CloneCommand extends BaseCommand
             $this->addCommandSubject2($to);
         }
 
-        $binaryVersion = '2.0.0.0';
-
         if (null !== $repoReference) {
             // git documentation says the --branch was added in 2.0.0, but it exists undocumented at least back to 1.8.3.1
             if (version_compare($binaryVersion, '1.8.3.1', '<')) {

--- a/src/GitElephant/Command/CloneCommand.php
+++ b/src/GitElephant/Command/CloneCommand.php
@@ -19,12 +19,13 @@
 
 namespace GitElephant\Command;
 
-use \GitElephant\Repository;
+use GitElephant\Repository;
 
 /**
  * CloneCommand generator
  *
  * @author Matteo Giachino <matteog@gmail.com>
+ * @author Kirk Madera <kmadera@robofirm.com>
  */
 class CloneCommand extends BaseCommand
 {
@@ -33,7 +34,7 @@ class CloneCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)
@@ -44,19 +45,47 @@ class CloneCommand extends BaseCommand
     /**
      * Command to clone a repository
      *
-     * @param string $url repository url
-     * @param string $to  where to clone the repo
+     * @param string      $url           repository url
+     * @param string      $to            where to clone the repo
+     * @param string|null $repoReference Repo reference to clone. Required if performing a shallow clone.
+     * @param int|null    $depth         Depth of commits to clone
+     * @param bool        $recursive     Whether to recursively clone submodules.
      *
      * @throws \RuntimeException
      * @return string command
      */
-    public function cloneUrl($url, $to = null)
+    public function cloneUrl(string $url, string $to = null, string $repoReference = null, int $depth = null, bool $recursive = false)
     {
         $this->clearAll();
         $this->addCommandName(static::GIT_CLONE_COMMAND);
         $this->addCommandSubject($url);
         if (null !== $to) {
             $this->addCommandSubject2($to);
+        }
+
+        $binaryVersion = '2.0.0.0';
+
+        if (null !== $repoReference) {
+            // git documentation says the --branch was added in 2.0.0, but it exists undocumented at least back to 1.8.3.1
+            if (version_compare($binaryVersion, '1.8.3.1', '<')) {
+                throw new \RuntimeException(
+                    'Please upgrade to git v1.8.3.1 or newer to support cloning a specific branch.'
+                );
+            }
+            $this->addCommandArgument('--branch=' . $repoReference);
+        }
+
+        if (null !== $depth) {
+            $this->addCommandArgument('--depth=' . $depth);
+            // shallow-submodules is a nice to have feature. Just ignoring if git version not high enough
+            // It would be nice if this had a logger injected for us to log notices
+            if (version_compare($binaryVersion, '2.9.0', '>=') && $recursive && 1 == $depth) {
+                $this->addCommandArgument('--shallow-submodules');
+            }
+        }
+
+        if ($recursive) {
+            $this->addCommandArgument('--recursive');
         }
 
         return $this->getCommand();

--- a/src/GitElephant/Repository.php
+++ b/src/GitElephant/Repository.php
@@ -966,19 +966,22 @@ class Repository
     /**
      * Clone a repository
      *
-     * @param string $url the repository url (i.e. git://github.com/matteosister/GitElephant.git)
-     * @param null   $to  where to clone the repo
+     * @param string      $url           the repository url (i.e. git://github.com/matteosister/GitElephant.git)
+     * @param null        $to            where to clone the repo
+     * @param string|null $repoReference Repo reference to clone. Required if performing a shallow clone.
+     * @param int|null    $depth         Depth to clone repo. Specify 1 to perform a shallow clone
+     * @param bool        $recursive     Whether to recursively clone child repos.
      *
      * @throws \RuntimeException
      * @throws \Symfony\Component\Process\Exception\LogicException
-     * @throws InvalidArgumentException
+     * @throws \Symfony\Component\Process\Exception\InvalidArgumentException
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function cloneFrom(string $url, string $to = null)
+    public function cloneFrom(string $url, string $to = null, string $repoReference = null, int $depth = null, bool $recursive = false)
     {
-        $this->caller->execute(CloneCommand::getInstance($this)->cloneUrl($url, $to));
-
+        $command = (Command\CloneCommand::getInstance($this))->cloneUrl($url, $to, $repoReference, $depth, $recursive);
+        $this->caller->execute($command);
         return $this;
     }
 

--- a/tests/GitElephant/Command/CloneCommandTest.php
+++ b/tests/GitElephant/Command/CloneCommandTest.php
@@ -26,11 +26,17 @@ use \GitElephant\Objects\Commit;
 class CloneCommandTest extends TestCase
 {
     /**
+     * @var string
+     */
+    private $binaryVersion;
+
+    /**
      * set up
      */
     public function setUp()
     {
         $this->initRepository();
+        $this->binaryVersion = exec('git --version | cut -d " " -f 3');
     }
 
     /**
@@ -46,6 +52,31 @@ class CloneCommandTest extends TestCase
         $this->assertEquals(
             "clone 'git://github.com/matteosister/GitElephant.git' 'test'",
             $cc->cloneUrl('git://github.com/matteosister/GitElephant.git', 'test')
+        );
+
+        if (version_compare($this->binaryVersion, '1.8.3.1', '<')) {
+            // Will fail if tested on git version 1.8.3.0 or lower
+            $this->expectException(\RuntimeException::class);
+        }
+        $this->assertEquals(
+            "clone '--branch=master' 'git://github.com/matteosister/GitElephant.git' 'test'",
+            $cc->cloneUrl('git://github.com/matteosister/GitElephant.git', 'test', 'master')
+        );
+
+        $this->assertEquals(
+            "clone '--depth=1' 'git://github.com/matteosister/GitElephant.git' 'test'",
+            $cc->cloneUrl('git://github.com/matteosister/GitElephant.git', 'test', null, 1)
+        );
+
+        // Output depends on git version used
+        if (version_compare($this->binaryVersion, '2.9.0', '<')) {
+            $expected = "clone '--depth=1' '--recursive' 'git://github.com/matteosister/GitElephant.git' 'test'";
+        } else {
+            $expected = "clone '--depth=1' '--shallow-submodules' '--recursive' 'git://github.com/matteosister/GitElephant.git' 'test'";
+        }
+        $this->assertEquals(
+            $expected,
+            $cc->cloneUrl('git://github.com/matteosister/GitElephant.git', 'test', null, 1, true)
         );
     }
 }

--- a/tests/GitElephant/RepositoryTest.php
+++ b/tests/GitElephant/RepositoryTest.php
@@ -656,7 +656,7 @@ class RepositoryTest extends TestCase
         $this->addFile('test', null, null, $remote);
         $remote->commit('test', true);
         $local = $this->getRepository(1);
-        $local->cloneFrom($remote->getPath(), '.');
+        $local->cloneFrom($remote->getPath(), '.', 'master', 1, false);
         $commit = $local->getCommit();
         $this->assertEquals($remote->getCommit()->getSha(), $commit->getSha());
         $this->assertEquals($remote->getCommit()->getMessage(), $commit->getMessage());


### PR DESCRIPTION
Depends on PR #147. The --branch command is only available at git 2.0.0 and higher and a lot of environments still run 1.8. Unit tests should pass once PR #147 is merged in and back down into this branch