### PR TITLE
Symfony 5 upgrade + CI improvements

### DIFF
--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -23,6 +23,11 @@ jobs:
                 with:
                     php-version: ${{ matrix.php }}
                     coverage: none # disable xdebug, pcov
+            
+            -   run: git --version
+            -   run: git config --global user.email "test@github.com"
+            -   run: git config --global user.name "GitHub Action"
+            -   run: git --version
 
             # if we 2 steps like this, we can better see if composer failed or tests
             -   run: composer install --no-progress

--- a/.github/workflows/code_checks.yaml
+++ b/.github/workflows/code_checks.yaml
@@ -1,0 +1,41 @@
+name: Code_Checks
+
+on:
+    pull_request: null
+    push:
+        branches:
+            - master
+
+jobs:
+    tests:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                php: ['7.2', '7.3', '7.4']
+
+        name: PHP ${{ matrix.php }} tests
+        steps:
+            # basically git clone
+            -   uses: actions/checkout@v2
+
+            # use PHP of specific version
+            -   uses: shivammathur/setup-php@v1
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: none # disable xdebug, pcov
+
+            # if we 2 steps like this, we can better see if composer failed or tests
+            -   run: composer install --no-progress
+
+            -   run: composer tests
+
+    code_style:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+            -   uses: shivammathur/setup-php@v1
+                with:
+                    php-version: 7.3
+                    coverage: none # disable xdebug, pcov
+            -   run: composer install --no-progress
+            -   run: composer check-cs

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,11 @@
 {
     "name": "cypresslab/gitelephant",
     "description": "An abstraction layer for git written in PHP",
+    "scripts": {
+        "tests": "./vendor/bin/phpunit",
+        "check-cs": "./vendor/bin/phpcs --exclude=Generic.Files.LineLength --standard=PSR2 src tests",
+        "fix-cs": "./vendor/bin/phpcbf --standard=PSR2 src tests"
+    },
     "keywords": [
         "git"
     ],
@@ -21,10 +26,11 @@
     },
     "require-dev": {
         "php": ">=7.2.0",
-        "phpunit/phpunit": "~9.0",
+        "phpunit/phpunit": "~8.0|~9.0",
         "mockery/mockery": "~1.1",
         "symfony/var-dumper": "~3.0|~4.0|~5.0",
-        "rector/rector": "^0.7.6"
+        "rector/rector": "^0.7.6",
+        "squizlabs/php_codesniffer": "^3.5.4"
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "php": ">=7.2.0",
         "phpunit/phpunit": "~9.0",
         "mockery/mockery": "~1.1",
-        "symfony/var-dumper": "~3.0|~4.0|~5.0"
+        "symfony/var-dumper": "~3.0|~4.0|~5.0",
+        "rector/rector": "^0.7.6"
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -31,5 +31,10 @@
         "psr-0": {
             "GitElephant": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-0": {
+            "GitElephant": "tests/"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,16 @@
     ],
     "require": {
         "php": ">=7.2.0",
-        "symfony/process": "~2.8|~3.0|~4.0",
-        "symfony/filesystem": "~2.8|~3.0|~4.0",
-        "symfony/finder": "~2.8|~3.0|~4.0",
-        "phpcollection/phpcollection": "~0.4"
+        "symfony/process": "~2.8|~3.0|~4.0|~5.0",
+        "symfony/filesystem": "~2.8|~3.0|~4.0|~5.0",
+        "symfony/finder": "~2.8|~3.0|~4.0|~5.0",
+        "phpcollection/phpcollection": "~0.4|~5.0"
     },
     "require-dev": {
         "php": ">=7.2.0",
-        "phpunit/phpunit": "~8.0",
+        "phpunit/phpunit": "~9.0",
         "mockery/mockery": "~1.1",
-        "symfony/var-dumper": "3.*|4.*"
+        "symfony/var-dumper": "~3.0|~4.0|~5.0"
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/rector.yaml
+++ b/rector.yaml
@@ -1,4 +1,10 @@
 parameters:
+    # autoload_paths:
+    #     - 'vendor/autoload.php'
+    paths:
+        - 'src'
+        - 'tests'
+    php_version_features: '7.2'
     sets:
         - 'code-quality'
         - 'symfony-code-quality'
@@ -6,3 +12,4 @@ parameters:
         - 'php72'
         - 'php73'
         - 'phpunit90'
+

--- a/rector.yaml
+++ b/rector.yaml
@@ -1,0 +1,8 @@
+parameters:
+    sets:
+        - 'code-quality'
+        - 'symfony-code-quality'
+        - 'php71'
+        - 'php72'
+        - 'php73'
+        - 'phpunit90'

--- a/src/GitElephant/Command/BaseCommand.php
+++ b/src/GitElephant/Command/BaseCommand.php
@@ -131,7 +131,7 @@ class BaseCommand
     /**
      * Clear all previous variables
      */
-    public function clearAll()
+    public function clearAll(): void
     {
         $this->commandName = null;
         $this->configs = array();
@@ -152,7 +152,7 @@ class BaseCommand
      *
      * @param string $commandName the command name
      */
-    protected function addCommandName($commandName)
+    protected function addCommandName($commandName): void
     {
         $this->commandName = $commandName;
     }
@@ -162,7 +162,7 @@ class BaseCommand
      *
      * @return string
      */
-    protected function getCommandName()
+    protected function getCommandName(): string
     {
         return $this->commandName;
     }
@@ -172,7 +172,7 @@ class BaseCommand
      *
      * @param array|Map $configs the config variable. i.e. { "color.status" => "false", "color.diff" => "true" }
      */
-    public function addConfigs($configs)
+    public function addConfigs($configs): void
     {
         foreach ($configs as $config => $value) {
             $this->configs[$config] = $value;
@@ -184,7 +184,7 @@ class BaseCommand
      *
      * @param array|Map $configs the config variable. i.e. { "color.status" => "false", "color.diff" => "true" }
      */
-    protected function addGlobalConfigs($configs)
+    protected function addGlobalConfigs($configs): void
     {
         if (!empty($configs)) {
             foreach ($configs as $config => $value) {
@@ -198,7 +198,7 @@ class BaseCommand
      *
      * @param array|Map $options a global option
      */
-    protected function addGlobalOptions($options)
+    protected function addGlobalOptions($options): void
     {
         if (!empty($options)) {
             foreach ($options as $name => $value) {
@@ -212,7 +212,7 @@ class BaseCommand
      *
      * @return array
      */
-    public function getConfigs()
+    public function getConfigs(): array
     {
         return $this->configs;
     }
@@ -222,7 +222,7 @@ class BaseCommand
      *
      * @param string $commandArgument the command argument
      */
-    protected function addCommandArgument($commandArgument)
+    protected function addCommandArgument($commandArgument): void
     {
         $this->commandArguments[] = $commandArgument;
     }
@@ -232,7 +232,7 @@ class BaseCommand
      *
      * @param string $commandArgument the command argument
      */
-    protected function addGlobalCommandArgument($commandArgument)
+    protected function addGlobalCommandArgument($commandArgument): void
     {
         if (!empty($commandArgument)) {
             $this->globalCommandArguments[] = $commandArgument;
@@ -244,9 +244,9 @@ class BaseCommand
      *
      * @return array
      */
-    protected function getCommandArguments()
+    protected function getCommandArguments(): array
     {
-        return ($this->commandArguments) ? $this->commandArguments : array();
+        return ($this->commandArguments !== []) ? $this->commandArguments : array();
     }
 
     /**
@@ -254,7 +254,7 @@ class BaseCommand
      *
      * @param SubCommandCommand|array|string $commandSubject the command subject
      */
-    protected function addCommandSubject($commandSubject)
+    protected function addCommandSubject($commandSubject): void
     {
         $this->commandSubject = $commandSubject;
     }
@@ -264,7 +264,7 @@ class BaseCommand
      *
      * @param SubCommandCommand|array|string $commandSubject2 the second command subject
      */
-    protected function addCommandSubject2($commandSubject2)
+    protected function addCommandSubject2($commandSubject2): void
     {
         $this->commandSubject2 = $commandSubject2;
     }
@@ -274,7 +274,7 @@ class BaseCommand
      *
      * @param string $path path
      */
-    protected function addPath($path)
+    protected function addPath($path): void
     {
         $this->path = $path;
     }
@@ -290,7 +290,7 @@ class BaseCommand
      *
      * @return array Associative array of valid, normalized command options
      */
-    public function normalizeOptions(array $options = array(), array $switchOptions = array(), $valueOptions = array())
+    public function normalizeOptions(array $options = array(), array $switchOptions = array(), $valueOptions = array()): array
     {
         $normalizedOptions = array();
 
@@ -299,10 +299,10 @@ class BaseCommand
                 $normalizedOptions[$switchOptions[$option]] = $switchOptions[$option];
             } else {
                 $parts = preg_split('/([\s=])+/', $option, 2, PREG_SPLIT_DELIM_CAPTURE);
-                if (count($parts)) {
+                if ((is_countable($parts) ? count($parts) : 0) > 0) {
                     $optionName = $parts[0];
                     if (in_array($optionName, $valueOptions)) {
-                        $value = ($parts[1] == '=') ? $option : array($parts[0], $parts[2]);
+                        $value = ($parts[1] === '=') ? $option : array($parts[0], $parts[2]);
                         $normalizedOptions[$optionName] = $value;
                     }
                 }
@@ -318,7 +318,7 @@ class BaseCommand
      * @return string
      * @throws \RuntimeException
      */
-    public function getCommand()
+    public function getCommand(): string
     {
         if (is_null($this->commandName)) {
             throw new \RuntimeException("You should pass a commandName to execute a command");
@@ -342,7 +342,7 @@ class BaseCommand
      *
      * @return string The command argument string
      */
-    private function getCLICommandArguments()
+    private function getCLICommandArguments(): string
     {
         $command = '';
         $combinedArguments = array_merge($this->globalCommandArguments, $this->commandArguments);
@@ -357,7 +357,7 @@ class BaseCommand
      *
      * @return string The command name string
      */
-    private function getCLICommandName()
+    private function getCLICommandName(): string
     {
         return ' ' . $this->commandName;
     }
@@ -367,11 +367,11 @@ class BaseCommand
      *
      * @return string The config string
      */
-    private function getCLIConfigs()
+    private function getCLIConfigs(): string
     {
         $command = '';
         $combinedConfigs = array_merge($this->globalConfigs, $this->configs);
-        if (count($combinedConfigs)) {
+        if (count($combinedConfigs) > 0) {
             foreach ($combinedConfigs as $config => $value) {
                 $command .= sprintf(
                     ' %s %s=%s',
@@ -389,7 +389,7 @@ class BaseCommand
      *
      * @return string The global options string
      */
-    private function getCLIGlobalOptions()
+    private function getCLIGlobalOptions(): string
     {
         $command = '';
         if (count($this->globalOptions) > 0) {
@@ -405,7 +405,7 @@ class BaseCommand
      *
      * @return string The path string
      */
-    private function getCLIPath()
+    private function getCLIPath(): string
     {
         $command = '';
         if (!is_null($this->path)) {
@@ -420,31 +420,27 @@ class BaseCommand
      * @throws \RuntimeException
      * @return string The subjects string
      */
-    private function getCLISubjects()
+    private function getCLISubjects(): string
     {
         $command = '';
         if (!is_null($this->commandSubject)) {
             $command .= ' ';
             if ($this->commandSubject instanceof SubCommandCommand) {
                 $command .= $this->commandSubject->getCommand();
+            } elseif (is_array($this->commandSubject)) {
+                $command .= implode(' ', array_map('escapeshellarg', $this->commandSubject));
             } else {
-                if (is_array($this->commandSubject)) {
-                    $command .= implode(' ', array_map('escapeshellarg', $this->commandSubject));
-                } else {
-                    $command .= escapeshellarg($this->commandSubject);
-                }
+                $command .= escapeshellarg($this->commandSubject);
             }
         }
         if (!is_null($this->commandSubject2)) {
             $command .= ' ';
             if ($this->commandSubject2 instanceof SubCommandCommand) {
                 $command .= $this->commandSubject2->getCommand();
+            } elseif (is_array($this->commandSubject2)) {
+                $command .= implode(' ', array_map('escapeshellarg', $this->commandSubject2));
             } else {
-                if (is_array($this->commandSubject2)) {
-                    $command .= implode(' ', array_map('escapeshellarg', $this->commandSubject2));
-                } else {
-                    $command .= escapeshellarg($this->commandSubject2);
-                }
+                $command .= escapeshellarg($this->commandSubject2);
             }
         }
         return $command;
@@ -453,7 +449,7 @@ class BaseCommand
     /**
      * @return string|null
      */
-    public function getBinaryVersion()
+    public function getBinaryVersion(): string
     {
         if (is_null($this->binaryVersion)) {
             $this->binaryVersion = $this->repo->getCaller()->getBinaryVersion();

--- a/src/GitElephant/Command/BranchCommand.php
+++ b/src/GitElephant/Command/BranchCommand.php
@@ -49,7 +49,7 @@ class BranchCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string the command
      */
-    public function contains($reference)
+    public function contains($reference): string
     {
         $this->clearAll();
         $this->addCommandName(self::BRANCH_COMMAND);
@@ -68,7 +68,7 @@ class BranchCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string the command
      */
-    public function create($name, $startPoint = null)
+    public function create($name, $startPoint = null): string
     {
         $this->clearAll();
         $this->addCommandName(self::BRANCH_COMMAND);
@@ -89,7 +89,7 @@ class BranchCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string the command
      */
-    public function listBranches($all = false, $simple = false)
+    public function listBranches($all = false, $simple = false): string
     {
         $this->clearAll();
         $this->addCommandName(self::BRANCH_COMMAND);
@@ -118,7 +118,7 @@ class BranchCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string the command
      */
-    public function lists($all = false, $simple = false)
+    public function lists($all = false, $simple = false): string
     {
         return $this->listBranches($all, $simple);
     }
@@ -134,7 +134,7 @@ class BranchCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function singleInfo($name, $all = false, $simple = false, $verbose = false)
+    public function singleInfo($name, $all = false, $simple = false, $verbose = false): string
     {
         $this->clearAll();
         $this->addCommandName(self::BRANCH_COMMAND);
@@ -164,9 +164,9 @@ class BranchCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string the command
      */
-    public function delete($name, $force = false)
+    public function delete($name, $force = false): string
     {
-        $arg = ($force === true) ? '-D' : '-d';
+        $arg = ($force) ? '-D' : '-d';
         $this->clearAll();
         $this->addCommandName(self::BRANCH_COMMAND);
         $this->addCommandArgument($arg);

--- a/src/GitElephant/Command/BranchCommand.php
+++ b/src/GitElephant/Command/BranchCommand.php
@@ -33,7 +33,7 @@ class BranchCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/Caller/AbstractCaller.php
+++ b/src/GitElephant/Command/Caller/AbstractCaller.php
@@ -50,7 +50,7 @@ abstract class AbstractCaller implements CallerInterface
     /**
      * @inheritdoc
      */
-    public function getBinaryPath()
+    public function getBinaryPath(): string
     {
         return $this->binaryPath;
     }
@@ -60,7 +60,7 @@ abstract class AbstractCaller implements CallerInterface
      *
      * @param string $path the path to the system git binary
      */
-    public function setBinaryPath(string $path)
+    public function setBinaryPath(string $path): self
     {
         $this->binaryPath = $path;
 
@@ -70,7 +70,7 @@ abstract class AbstractCaller implements CallerInterface
     /**
      * @inheritdoc
      */
-    public function getBinaryVersion()
+    public function getBinaryVersion(): string
     {
         if (is_null($this->binaryVersion)) {
             $this->execute('--version');
@@ -89,7 +89,7 @@ abstract class AbstractCaller implements CallerInterface
      *
      * @return string
      */
-    public function getOutput()
+    public function getOutput(): string
     {
         return implode("\n", $this->outputLines);
     }
@@ -101,7 +101,7 @@ abstract class AbstractCaller implements CallerInterface
      *
      * @return array
      */
-    public function getOutputLines($stripBlankLines = false)
+    public function getOutputLines($stripBlankLines = false): array
     {
         if ($stripBlankLines) {
             $output = array();

--- a/src/GitElephant/Command/Caller/AbstractCaller.php
+++ b/src/GitElephant/Command/Caller/AbstractCaller.php
@@ -73,7 +73,8 @@ abstract class AbstractCaller implements CallerInterface
     public function getBinaryVersion()
     {
         if (is_null($this->binaryVersion)) {
-            $version = $this->execute('--version')->getOutput();
+            $this->execute('--version');
+            $version = $this->getOutput();
             if (!preg_match('/^git version [0-9\.]+/', $version)) {
                 throw new \RuntimeException('Could not parse git version. Unexpected format "' . $version . '".');
             }

--- a/src/GitElephant/Command/Caller/Caller.php
+++ b/src/GitElephant/Command/Caller/Caller.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * GitElephant - An abstraction layer for git written in PHP
  * Copyright (C) 2013  Matteo Giachino
@@ -91,7 +92,10 @@ class Caller extends AbstractCaller
             $cmd = 'LC_ALL=C ' . $cmd;
         }
 
-        $process = new Process($cmd, is_null($cwd) ? $this->repositoryPath : $cwd);
+        if (is_null($cwd) || !is_dir($cwd)) {
+            $cwd = $this->repositoryPath;
+        }
+        $process = Process::fromShellCommandline($cmd, $cwd);
         $process->setTimeout(15000);
         $process->run();
         if (!in_array($process->getExitCode(), $acceptedExitCodes)) {

--- a/src/GitElephant/Command/Caller/Caller.php
+++ b/src/GitElephant/Command/Caller/Caller.php
@@ -81,7 +81,7 @@ class Caller extends AbstractCaller
      * @throws \Symfony\Component\Process\Exception\LogicException
      * @return Caller
      */
-    public function execute($cmd, $git = true, $cwd = null, $acceptedExitCodes = array(0))
+    public function execute($cmd, $git = true, $cwd = null, $acceptedExitCodes = array(0)): \GitElephant\Command\Caller\CallerInterface
     {
         if ($git) {
             $cmd = $this->getBinaryPath() . ' ' . $cmd;
@@ -119,7 +119,7 @@ class Caller extends AbstractCaller
      *
      * @return string
      */
-    public function getOutput()
+    public function getOutput(): string
     {
         return implode("\n", $this->outputLines);
     }
@@ -131,7 +131,7 @@ class Caller extends AbstractCaller
      *
      * @return array
      */
-    public function getOutputLines($stripBlankLines = false)
+    public function getOutputLines($stripBlankLines = false): array
     {
         if ($stripBlankLines) {
             $output = array();
@@ -152,7 +152,7 @@ class Caller extends AbstractCaller
      *
      * @return string
      */
-    public function getRawOutput()
+    public function getRawOutput(): string
     {
         return $this->rawOutput;
     }

--- a/src/GitElephant/Command/Caller/CallerInterface.php
+++ b/src/GitElephant/Command/Caller/CallerInterface.php
@@ -33,7 +33,7 @@ interface CallerInterface
      *
      * @return CallerInterface
      */
-    public function execute($cmd, $git = true, $cwd = null);
+    public function execute($cmd, $git = true, $cwd = null): \GitElephant\Command\Caller\CallerInterface;
 
     /**
      * after calling execute this method should return the output
@@ -42,19 +42,19 @@ interface CallerInterface
      *
      * @return array
      */
-    public function getOutputLines($stripBlankLines = false);
+    public function getOutputLines($stripBlankLines = false): array;
 
     /**
      * Get the binary path
      *
      * @return string
      */
-    public function getBinaryPath();
+    public function getBinaryPath(): string;
 
     /**
      * Get the binary version
      *
      * @return string
      */
-    public function getBinaryVersion();
+    public function getBinaryVersion(): string;
 }

--- a/src/GitElephant/Command/Caller/CallerSSH2.php
+++ b/src/GitElephant/Command/Caller/CallerSSH2.php
@@ -56,7 +56,7 @@ class CallerSSH2 extends AbstractCaller
      *
      * @return CallerInterface
      */
-    public function execute($cmd, $git = true, $cwd = null)
+    public function execute($cmd, $git = true, $cwd = null): \GitElephant\Command\Caller\CallerInterface
     {
         if ($git) {
             $cmd = $this->getBinaryPath() . ' ' . $cmd;

--- a/src/GitElephant/Command/Caller/CallerSSH2.php
+++ b/src/GitElephant/Command/Caller/CallerSSH2.php
@@ -71,5 +71,4 @@ class CallerSSH2 extends AbstractCaller
 
         return $this;
     }
-
 }

--- a/src/GitElephant/Command/CatFileCommand.php
+++ b/src/GitElephant/Command/CatFileCommand.php
@@ -52,14 +52,10 @@ class CatFileCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function content(NodeObject $object, $treeish)
+    public function content(NodeObject $object, $treeish): string
     {
         $this->clearAll();
-        if ($treeish instanceof TreeishInterface) {
-            $sha = $treeish->getSha();
-        } else {
-            $sha = $treeish;
-        }
+        $sha = $treeish instanceof TreeishInterface ? $treeish->getSha() : $treeish;
         $this->addCommandName(static::GIT_CAT_FILE);
         // pretty format
         $this->addCommandArgument('-p');
@@ -76,7 +72,7 @@ class CatFileCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function contentBySha($sha)
+    public function contentBySha($sha): string
     {
         $this->clearAll();
         $this->addCommandName(static::GIT_CAT_FILE);

--- a/src/GitElephant/Command/CatFileCommand.php
+++ b/src/GitElephant/Command/CatFileCommand.php
@@ -35,7 +35,7 @@ class CatFileCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/CloneCommand.php
+++ b/src/GitElephant/Command/CloneCommand.php
@@ -54,7 +54,7 @@ class CloneCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string command
      */
-    public function cloneUrl(string $url, string $to = null, string $repoReference = null, int $depth = null, bool $recursive = false)
+    public function cloneUrl(string $url, string $to = null, string $repoReference = null, int $depth = null, bool $recursive = false): string
     {
         // get binary version before reset
         $v = $this->getBinaryVersion();

--- a/src/GitElephant/Command/DiffCommand.php
+++ b/src/GitElephant/Command/DiffCommand.php
@@ -34,7 +34,7 @@ class DiffCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/DiffCommand.php
+++ b/src/GitElephant/Command/DiffCommand.php
@@ -52,7 +52,7 @@ class DiffCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function diff($of, $with = null, $path = null)
+    public function diff($of, $with = null, $path = null): string
     {
         $this->clearAll();
         $this->addCommandName(self::DIFF_COMMAND);

--- a/src/GitElephant/Command/DiffTreeCommand.php
+++ b/src/GitElephant/Command/DiffTreeCommand.php
@@ -36,7 +36,7 @@ class DiffTreeCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/DiffTreeCommand.php
+++ b/src/GitElephant/Command/DiffTreeCommand.php
@@ -53,7 +53,7 @@ class DiffTreeCommand extends BaseCommand
      * @throws \InvalidArgumentException
      * @return string
      */
-    public function rootDiff(Commit $commit)
+    public function rootDiff(Commit $commit): string
     {
         if (!$commit->isRoot()) {
             throw new \InvalidArgumentException('rootDiff method accepts only root commits');

--- a/src/GitElephant/Command/FetchCommand.php
+++ b/src/GitElephant/Command/FetchCommand.php
@@ -51,7 +51,7 @@ class FetchCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function fetch($remote = null, $branch = null, Array $options = array())
+    public function fetch($remote = null, $branch = null, Array $options = array()): string
     {
         if ($remote instanceof Remote) {
             $remote = $remote->getName();
@@ -83,7 +83,7 @@ class FetchCommand extends BaseCommand
      *
      * @return array Associative array mapping all non-value options and their respective normalized option
      */
-    public function fetchCmdSwitchOptions()
+    public function fetchCmdSwitchOptions(): array
     {
         return array(
             self::GIT_FETCH_OPTION_TAGS => self::GIT_FETCH_OPTION_TAGS,

--- a/src/GitElephant/Command/FetchCommand.php
+++ b/src/GitElephant/Command/FetchCommand.php
@@ -35,7 +35,7 @@ class FetchCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/LogCommand.php
+++ b/src/GitElephant/Command/LogCommand.php
@@ -56,7 +56,7 @@ class LogCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function showObjectLog(NodeObject $obj, $branch = null, $limit = null, $offset = null)
+    public function showObjectLog(NodeObject $obj, $branch = null, $limit = null, $offset = null): string
     {
         $subject = null;
         if (null !== $branch) {
@@ -83,7 +83,7 @@ class LogCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function showLog($ref, $path = null, $limit = null, $offset = null, $firstParent = false)
+    public function showLog($ref, $path = null, $limit = null, $offset = null, $firstParent = false): string
     {
         $this->clearAll();
 
@@ -102,7 +102,7 @@ class LogCommand extends BaseCommand
             $this->addCommandArgument('--skip=' . $offset);
         }
 
-        if (true === $firstParent) {
+        if ($firstParent) {
             $this->addCommandArgument('--first-parent');
         }
 

--- a/src/GitElephant/Command/LogCommand.php
+++ b/src/GitElephant/Command/LogCommand.php
@@ -37,7 +37,7 @@ class LogCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/LogRangeCommand.php
+++ b/src/GitElephant/Command/LogRangeCommand.php
@@ -31,7 +31,7 @@ class LogRangeCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/LogRangeCommand.php
+++ b/src/GitElephant/Command/LogRangeCommand.php
@@ -53,7 +53,7 @@ class LogRangeCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function showLog($refStart, $refEnd, $path = null, $limit = null, $offset = null, $firstParent = false)
+    public function showLog($refStart, $refEnd, $path = null, $limit = null, $offset = null, $firstParent = false): string
     {
         $this->clearAll();
 
@@ -72,7 +72,7 @@ class LogRangeCommand extends BaseCommand
             $this->addCommandArgument('--skip=' . $offset);
         }
 
-        if (true === $firstParent) {
+        if ($firstParent) {
             $this->addCommandArgument('--first-parent');
         }
 

--- a/src/GitElephant/Command/LsTreeCommand.php
+++ b/src/GitElephant/Command/LsTreeCommand.php
@@ -52,7 +52,7 @@ class LsTreeCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function fullTree($ref = 'HEAD')
+    public function fullTree($ref = 'HEAD'): string
     {
         $what = $ref;
         if ($ref instanceof TreeishInterface) {
@@ -79,7 +79,7 @@ class LsTreeCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function tree($ref = 'HEAD', $path = null)
+    public function tree($ref = 'HEAD', $path = null): string
     {
         if ($path instanceof NodeObject) {
             $subjectPath = $path->getFullPath() . ($path->isTree() ? '/' : '');
@@ -110,7 +110,7 @@ class LsTreeCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function listAll($ref = null)
+    public function listAll($ref = null): string
     {
         if (is_null($ref)) {
             $ref = 'HEAD';

--- a/src/GitElephant/Command/LsTreeCommand.php
+++ b/src/GitElephant/Command/LsTreeCommand.php
@@ -83,8 +83,7 @@ class LsTreeCommand extends BaseCommand
     {
         if ($path instanceof NodeObject) {
             $subjectPath = $path->getFullPath() . ($path->isTree() ? '/' : '');
-        }
-        else {
+        } else {
             $subjectPath = $path;
         }
 

--- a/src/GitElephant/Command/MainCommand.php
+++ b/src/GitElephant/Command/MainCommand.php
@@ -59,7 +59,7 @@ class MainCommand extends BaseCommand
      * @throws \RuntimeException
      * @return MainCommand
      */
-    public function init($bare = false)
+    public function init($bare = false): string
     {
         $this->clearAll();
         if ($bare) {
@@ -78,7 +78,7 @@ class MainCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function status($porcelain = false)
+    public function status($porcelain = false): string
     {
         $this->clearAll();
         $this->addCommandName(self::GIT_STATUS);
@@ -99,7 +99,7 @@ class MainCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function add($what = '.')
+    public function add($what = '.'): string
     {
         $this->clearAll();
         $this->addCommandName(self::GIT_ADD);
@@ -117,7 +117,7 @@ class MainCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function unstage($what)
+    public function unstage($what): string
     {
         $this->clearAll();
         $this->addCommandName(self::GIT_RESET);
@@ -138,7 +138,7 @@ class MainCommand extends BaseCommand
      * @throws \InvalidArgumentException
      * @return string
      */
-    public function commit($message, $stageAll = false, $author = null, $allowEmpty = false)
+    public function commit($message, $stageAll = false, $author = null, $allowEmpty = false): string
     {
         $this->clearAll();
         if (trim($message) === '' || is_null($message)) {
@@ -173,7 +173,7 @@ class MainCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function checkout($ref)
+    public function checkout($ref): string
     {
         $this->clearAll();
 
@@ -201,7 +201,7 @@ class MainCommand extends BaseCommand
      * @throws \InvalidArgumentException
      * @return string
      */
-    public function move($from, $to)
+    public function move($from, $to): string
     {
         $this->clearAll();
 
@@ -233,7 +233,7 @@ class MainCommand extends BaseCommand
      * @throws \InvalidArgumentException
      * @return string
      */
-    public function remove($path, $recursive, $force)
+    public function remove($path, $recursive, $force): string
     {
         $this->clearAll();
 
@@ -264,7 +264,7 @@ class MainCommand extends BaseCommand
      *
      * @return bool
      */
-    protected function validatePath($path)
+    protected function validatePath($path): bool
     {
         if (empty($path)) {
             return false;

--- a/src/GitElephant/Command/MainCommand.php
+++ b/src/GitElephant/Command/MainCommand.php
@@ -43,7 +43,7 @@ class MainCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/MergeCommand.php
+++ b/src/GitElephant/Command/MergeCommand.php
@@ -54,7 +54,7 @@ class MergeCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function merge(Branch $with, $message = '', Array $options = array())
+    public function merge(Branch $with, $message = '', Array $options = array()): string
     {
         if (in_array(self::MERGE_OPTION_FF_ONLY, $options) && in_array(self::MERGE_OPTION_NO_FF, $options)) {
             throw new \Symfony\Component\Process\Exception\InvalidArgumentException("Invalid options: cannot use flags --ff-only and --no-ff together.");
@@ -83,7 +83,7 @@ class MergeCommand extends BaseCommand
      *
      * @return array Associative array mapping all non-value options and their respective normalized option
      */
-    public function mergeCmdSwitchOptions()
+    public function mergeCmdSwitchOptions(): array
     {
         return array(
             self::MERGE_OPTION_FF_ONLY => self::MERGE_OPTION_FF_ONLY,

--- a/src/GitElephant/Command/MergeCommand.php
+++ b/src/GitElephant/Command/MergeCommand.php
@@ -36,7 +36,7 @@ class MergeCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/MvCommand.php
+++ b/src/GitElephant/Command/MvCommand.php
@@ -50,7 +50,7 @@ class MvCommand extends BaseCommand
      * @throws \InvalidArgumentException
      * @return string
      */
-    public function rename($source, $target)
+    public function rename($source, $target): string
     {
         if ($source instanceof NodeObject) {
             if (!$source->isBlob()) {

--- a/src/GitElephant/Command/MvCommand.php
+++ b/src/GitElephant/Command/MvCommand.php
@@ -34,7 +34,7 @@ class MvCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/PullCommand.php
+++ b/src/GitElephant/Command/PullCommand.php
@@ -34,7 +34,7 @@ class PullCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/PullCommand.php
+++ b/src/GitElephant/Command/PullCommand.php
@@ -50,7 +50,7 @@ class PullCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function pull($remote = null, $branch = null, $rebase = false)
+    public function pull($remote = null, $branch = null, $rebase = false): string
     {
         if ($remote instanceof Remote) {
             $remote = $remote->getName();

--- a/src/GitElephant/Command/PushCommand.php
+++ b/src/GitElephant/Command/PushCommand.php
@@ -49,7 +49,7 @@ class PushCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function push($remote = 'origin', $branch = 'master', string $args = null)
+    public function push($remote = 'origin', $branch = 'master', string $args = null): string
     {
         if ($remote instanceof Remote) {
             $remote = $remote->getName();

--- a/src/GitElephant/Command/PushCommand.php
+++ b/src/GitElephant/Command/PushCommand.php
@@ -34,7 +34,7 @@ class PushCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)
@@ -62,7 +62,7 @@ class PushCommand extends BaseCommand
         $this->addCommandSubject($remote);
         $this->addCommandSubject2($branch);
 
-        if(!is_null($args)) {
+        if (!is_null($args)) {
             $this->addCommandArgument($args);
         }
 

--- a/src/GitElephant/Command/Remote/AddSubCommand.php
+++ b/src/GitElephant/Command/Remote/AddSubCommand.php
@@ -44,7 +44,7 @@ class AddSubCommand extends SubCommandCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/Remote/AddSubCommand.php
+++ b/src/GitElephant/Command/Remote/AddSubCommand.php
@@ -57,7 +57,7 @@ class AddSubCommand extends SubCommandCommand
      *
      * @return array Array of all value-required options
      */
-    public function addCmdValueOptions()
+    public function addCmdValueOptions(): array
     {
         return array(
             self::GIT_REMOTE_ADD_OPTION_TRACK => self::GIT_REMOTE_ADD_OPTION_TRACK,
@@ -71,7 +71,7 @@ class AddSubCommand extends SubCommandCommand
      *
      * @return array
      */
-    public function addCmdSwitchOptions()
+    public function addCmdSwitchOptions(): array
     {
         return array(
             self::GIT_REMOTE_ADD_OPTION_TAGS => self::GIT_REMOTE_ADD_OPTION_TAGS,
@@ -89,7 +89,7 @@ class AddSubCommand extends SubCommandCommand
      *
      * @return string
      */
-    public function prepare($name, $url, $options = array())
+    public function prepare($name, $url, $options = array()): self
     {
         $options = $this->normalizeOptions(
             $options,

--- a/src/GitElephant/Command/Remote/ShowSubCommand.php
+++ b/src/GitElephant/Command/Remote/ShowSubCommand.php
@@ -38,7 +38,7 @@ class ShowSubCommand extends SubCommandCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/Remote/ShowSubCommand.php
+++ b/src/GitElephant/Command/Remote/ShowSubCommand.php
@@ -57,14 +57,13 @@ class ShowSubCommand extends SubCommandCommand
      *
      * @return ShowSubCommand
      */
-    public function prepare($name = null, $queryRemotes = true)
+    public function prepare($name = null, $queryRemotes = true): self
     {
         $this->addCommandName(self::GIT_REMOTE_SHOW);
         /**
          *  only add subject if relevant,
          *  otherwise on repositories without a remote defined (ie, fresh
          *  init'd or mock) will likely trigger warning/error condition
-         *
          */
         if ($name) {
             $this->addCommandSubject($name);

--- a/src/GitElephant/Command/RemoteCommand.php
+++ b/src/GitElephant/Command/RemoteCommand.php
@@ -40,7 +40,7 @@ class RemoteCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/RemoteCommand.php
+++ b/src/GitElephant/Command/RemoteCommand.php
@@ -61,7 +61,7 @@ class RemoteCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string Command string to pass to caller
      */
-    public function remote(SubCommandCommand $subcommand = null, Array $options = array())
+    public function remote(SubCommandCommand $subcommand = null, Array $options = array()): string
     {
         $normalizedOptions = $this->normalizeOptions($options, $this->remoteCmdSwitchOptions());
 
@@ -73,7 +73,7 @@ class RemoteCommand extends BaseCommand
             $this->addCommandArgument($value);
         }
 
-        if ($subcommand) {
+        if ($subcommand !== null) {
             $this->addCommandSubject($subcommand);
         }
 
@@ -85,7 +85,7 @@ class RemoteCommand extends BaseCommand
      *
      * @return array Associative array mapping all non-value options and their respective normalized option
      */
-    public function remoteCmdSwitchOptions()
+    public function remoteCmdSwitchOptions(): array
     {
         return array(
             self::GIT_REMOTE_OPTION_VERBOSE => self::GIT_REMOTE_OPTION_VERBOSE,
@@ -99,7 +99,7 @@ class RemoteCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function verbose()
+    public function verbose(): string
     {
         return $this->remote(null, array(self::GIT_REMOTE_OPTION_VERBOSE));
     }
@@ -116,7 +116,7 @@ class RemoteCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function show($name = null, $queryRemotes = true)
+    public function show($name = null, $queryRemotes = true): string
     {
         $subcmd = new ShowSubCommand();
         $subcmd->prepare($name, $queryRemotes);
@@ -134,7 +134,7 @@ class RemoteCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function add($name, $url, $options = array())
+    public function add($name, $url, $options = array()): string
     {
         $subcmd = new AddSubCommand();
         $subcmd->prepare($name, $url, $options);

--- a/src/GitElephant/Command/ResetCommand.php
+++ b/src/GitElephant/Command/ResetCommand.php
@@ -39,7 +39,7 @@ class ResetCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function reset($arg = null, array $options = array())
+    public function reset($arg = null, array $options = array()): string
     {
         $this->clearAll();
         $this->addCommandName(self::GIT_RESET_COMMAND);
@@ -60,7 +60,7 @@ class ResetCommand extends BaseCommand
      * @param Repository $repository
      * @return ResetCommand
      */
-    public static function getInstance(Repository $repository=null)
+    public static function getInstance(Repository $repository=null): \GitElephant\Command\ResetCommand
     {
         return new self($repository);
     }

--- a/src/GitElephant/Command/ResetCommand.php
+++ b/src/GitElephant/Command/ResetCommand.php
@@ -8,7 +8,6 @@
 
 namespace GitElephant\Command;
 
-
 use GitElephant\Objects\Commit;
 use GitElephant\Objects\TreeishInterface;
 use \GitElephant\Repository;
@@ -49,7 +48,7 @@ class ResetCommand extends BaseCommand
                 $this->addCommandArgument($option);
             }
         }
-        if($arg!=null){
+        if ($arg!=null) {
             $this->addCommandSubject2($arg);
         }
 
@@ -60,11 +59,8 @@ class ResetCommand extends BaseCommand
      * @param Repository $repository
      * @return ResetCommand
      */
-    public static function getInstance(Repository $repository=null): \GitElephant\Command\ResetCommand
+    public static function getInstance(Repository $repository = null): \GitElephant\Command\ResetCommand
     {
         return new self($repository);
     }
-
-
-
 }

--- a/src/GitElephant/Command/RevListCommand.php
+++ b/src/GitElephant/Command/RevListCommand.php
@@ -35,7 +35,7 @@ class RevListCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/RevListCommand.php
+++ b/src/GitElephant/Command/RevListCommand.php
@@ -51,7 +51,7 @@ class RevListCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function getTagCommit(Tag $tag)
+    public function getTagCommit(Tag $tag): string
     {
         $this->clearAll();
         $this->addCommandName(static::GIT_REVLIST);
@@ -71,7 +71,7 @@ class RevListCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function commitPath(Commit $commit, $max = 1000)
+    public function commitPath(Commit $commit, $max = 1000): string
     {
         $this->clearAll();
         $this->addCommandName(static::GIT_REVLIST);

--- a/src/GitElephant/Command/RevParseCommand.php
+++ b/src/GitElephant/Command/RevParseCommand.php
@@ -85,7 +85,7 @@ class RevParseCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function revParse($arg = null, Array $options = array())
+    public function revParse($arg = null, Array $options = array()): string
     {
         $this->clearAll();
         $this->addCommandName(self::GIT_REV_PARSE_COMMAND);

--- a/src/GitElephant/Command/RevParseCommand.php
+++ b/src/GitElephant/Command/RevParseCommand.php
@@ -70,7 +70,7 @@ class RevParseCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/ShowCommand.php
+++ b/src/GitElephant/Command/ShowCommand.php
@@ -33,7 +33,7 @@ class ShowCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/ShowCommand.php
+++ b/src/GitElephant/Command/ShowCommand.php
@@ -49,7 +49,7 @@ class ShowCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function showCommit($ref)
+    public function showCommit($ref): string
     {
         $this->clearAll();
 

--- a/src/GitElephant/Command/StashCommand.php
+++ b/src/GitElephant/Command/StashCommand.php
@@ -51,7 +51,7 @@ class StashCommand extends BaseCommand
      *
      * @return string
      */
-    public function save($message = null, $includeUntracked = false, $keepIndex = false)
+    public function save($message = null, $includeUntracked = false, $keepIndex = false): string
     {
         $this->clearAll();
         $this->addCommandName(self::STASH_COMMAND . ' save');
@@ -77,7 +77,7 @@ class StashCommand extends BaseCommand
      *
      * @return string
      */
-    public function listStashes(array $options = null)
+    public function listStashes(array $options = null): string
     {
         $this->clearAll();
         $this->addCommandName(self::STASH_COMMAND . ' list');
@@ -94,7 +94,7 @@ class StashCommand extends BaseCommand
      *
      * @return string
      */
-    public function show($stash)
+    public function show($stash): string
     {
         $stash = $this->normalizeStashName($stash);
         $this->clearAll();
@@ -110,7 +110,7 @@ class StashCommand extends BaseCommand
      *
      * @return string
      */
-    public function drop($stash)
+    public function drop($stash): string
     {
         $stash = $this->normalizeStashName($stash);
         $this->clearAll();
@@ -127,7 +127,7 @@ class StashCommand extends BaseCommand
      *
      * @return string
      */
-    public function apply($stash, $index = false)
+    public function apply($stash, $index = false): string
     {
         $stash = $this->normalizeStashName($stash);
         $this->clearAll();
@@ -147,7 +147,7 @@ class StashCommand extends BaseCommand
      *
      * @return string
      */
-    public function pop($stash, $index = false)
+    public function pop($stash, $index = false): string
     {
         $stash = $this->normalizeStashName($stash);
         $this->clearAll();
@@ -167,7 +167,7 @@ class StashCommand extends BaseCommand
      *
      * @return string
      */
-    public function branch($branch, $stash)
+    public function branch($branch, $stash): string
     {
         $stash = $this->normalizeStashName($stash);
         $this->clearAll();
@@ -179,9 +179,8 @@ class StashCommand extends BaseCommand
 
     /**
      *  Remove all the stashed states.
-     *
      */
-    public function clear()
+    public function clear(): string
     {
         $this->clearAll();
         $this->addCommandName(self::STASH_COMMAND . ' clear');
@@ -191,9 +190,8 @@ class StashCommand extends BaseCommand
     /**
      * Create a stash (which is a regular commit object) and return its object name, without storing it anywhere in the
      * ref namespace.
-     *
      */
-    public function create()
+    public function create(): string
     {
         $this->clearAll();
         $this->addCommandName(self::STASH_COMMAND . ' create');
@@ -205,7 +203,7 @@ class StashCommand extends BaseCommand
      *
      * @return string
      */
-    private function normalizeStashName($stash)
+    private function normalizeStashName($stash): string
     {
         if (0 !== strpos($stash, 'stash@{')) {
             $stash = 'stash@{' . $stash . '}';

--- a/src/GitElephant/Command/StashCommand.php
+++ b/src/GitElephant/Command/StashCommand.php
@@ -210,5 +210,4 @@ class StashCommand extends BaseCommand
         }
         return $stash;
     }
-
 }

--- a/src/GitElephant/Command/SubCommandCommand.php
+++ b/src/GitElephant/Command/SubCommandCommand.php
@@ -52,23 +52,23 @@ class SubCommandCommand extends BaseCommand
     /**
      * Clear all previous variables
      */
-    public function clearAll()
+    public function clearAll(): void
     {
         parent::clearAll();
         $this->orderedSubjects = null;
     }
 
-    protected function addCommandSubject($subject)
+    protected function addCommandSubject($subject): void
     {
         $this->orderedSubjects[] = $subject;
     }
 
     protected function getCommandSubjects()
     {
-        return ($this->orderedSubjects) ? $this->orderedSubjects : array();
+        return ($this->orderedSubjects !== []) ? $this->orderedSubjects : array();
     }
 
-    protected function extractArguments($args)
+    protected function extractArguments($args): string
     {
         $orderArgs = array();
         foreach ($args as $arg) {
@@ -92,7 +92,7 @@ class SubCommandCommand extends BaseCommand
      * @return string
      * @throws \RuntimeException
      */
-    public function getCommand()
+    public function getCommand(): string
     {
         $command = $this->getCommandName();
 
@@ -107,7 +107,7 @@ class SubCommandCommand extends BaseCommand
             $command .= ' ';
         }
         $subjects = $this->getCommandSubjects();
-        if (count($subjects) > 0) {
+        if ((is_countable($subjects) ? count($subjects) : 0) > 0) {
             $command .= implode(' ', array_map('escapeshellarg', $subjects));
         }
         $command = preg_replace('/\\s{2,}/', ' ', $command);

--- a/src/GitElephant/Command/SubCommandCommand.php
+++ b/src/GitElephant/Command/SubCommandCommand.php
@@ -41,7 +41,7 @@ class SubCommandCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/SubmoduleCommand.php
+++ b/src/GitElephant/Command/SubmoduleCommand.php
@@ -56,7 +56,7 @@ class SubmoduleCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function add($gitUrl, $path = null)
+    public function add($gitUrl, $path = null): string
     {
         $this->clearAll();
         $this->addCommandName(sprintf('%s %s', self::SUBMODULE_COMMAND, self::SUBMODULE_ADD_COMMAND));
@@ -75,7 +75,7 @@ class SubmoduleCommand extends BaseCommand
      *
      * @return string
      */
-    public function init($path = null)
+    public function init($path = null): string
     {
         $this->clearAll();
         $this->addCommandName(sprintf('%s %s', self::SUBMODULE_COMMAND, self::SUBMODULE_INIT_COMMAND));
@@ -92,7 +92,7 @@ class SubmoduleCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string the command
      */
-    public function listSubmodules()
+    public function listSubmodules(): string
     {
         $this->clearAll();
         $this->addCommandName(self::SUBMODULE_COMMAND);
@@ -110,7 +110,7 @@ class SubmoduleCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string the command
      */
-    public function lists()
+    public function lists(): string
     {
         return $this->listSubmodules();
     }
@@ -125,17 +125,17 @@ class SubmoduleCommand extends BaseCommand
      *
      * @return string
      */
-    public function update($recursive = false, $init = false, $force = false, $path = null)
+    public function update($recursive = false, $init = false, $force = false, $path = null): string
     {
         $this->clearAll();
         $this->addCommandName(sprintf('%s %s', self::SUBMODULE_COMMAND, self::SUBMODULE_UPDATE_COMMAND));
-        if ($recursive === true) {
+        if ($recursive) {
             $this->addCommandArgument(self::SUBMODULE_OPTION_RECURSIVE);
         }
-        if ($init === true) {
+        if ($init) {
             $this->addCommandArgument(self::SUBMODULE_OPTION_INIT);
         }
-        if ($force === true) {
+        if ($force) {
             $this->addCommandArgument(self::SUBMODULE_OPTION_FORCE);
         }
         if ($path !== null) {

--- a/src/GitElephant/Command/SubmoduleCommand.php
+++ b/src/GitElephant/Command/SubmoduleCommand.php
@@ -39,7 +39,7 @@ class SubmoduleCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Command/TagCommand.php
+++ b/src/GitElephant/Command/TagCommand.php
@@ -52,7 +52,7 @@ class TagCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string the command
      */
-    public function create(string $name, $startPoint = null, $message = null)
+    public function create(string $name, $startPoint = null, $message = null): string
     {
         $this->clearAll();
         $this->addCommandName(self::TAG_COMMAND);
@@ -76,7 +76,7 @@ class TagCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string the command
      */
-    public function listTags()
+    public function listTags(): string
     {
         $this->clearAll();
         $this->addCommandName(self::TAG_COMMAND);
@@ -94,7 +94,7 @@ class TagCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string the command
      */
-    public function lists()
+    public function lists(): string
     {
         return $this->listTags();
     }
@@ -107,7 +107,7 @@ class TagCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string the command
      */
-    public function delete($tag)
+    public function delete($tag): string
     {
         $this->clearAll();
 

--- a/src/GitElephant/Command/TagCommand.php
+++ b/src/GitElephant/Command/TagCommand.php
@@ -34,7 +34,7 @@ class TagCommand extends BaseCommand
     /**
      * constructor
      *
-     * @param \GitElephant\Repository $repo The repository object this command 
+     * @param \GitElephant\Repository $repo The repository object this command
      *                                      will interact with
      */
     public function __construct(Repository $repo = null)

--- a/src/GitElephant/Objects/Author.php
+++ b/src/GitElephant/Objects/Author.php
@@ -45,7 +45,7 @@ class Author
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->name . ' <' . $this->email . '>';
     }
@@ -55,7 +55,7 @@ class Author
      *
      * @param string $email the email
      */
-    public function setEmail(string $email)
+    public function setEmail(string $email): void
     {
         $this->email = $email;
     }
@@ -65,7 +65,7 @@ class Author
      *
      * @return string
      */
-    public function getEmail()
+    public function getEmail(): string
     {
         return $this->email;
     }
@@ -75,7 +75,7 @@ class Author
      *
      * @param string $name the author name
      */
-    public function setName(string $name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
@@ -85,7 +85,7 @@ class Author
      *
      * @return mixed
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/src/GitElephant/Objects/Branch.php
+++ b/src/GitElephant/Objects/Branch.php
@@ -78,7 +78,7 @@ class Branch extends NodeObject implements TreeishInterface
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return \GitElephant\Objects\Branch
      */
-    public static function create(Repository $repository, string $name, string $startPoint = null)
+    public static function create(Repository $repository, string $name, string $startPoint = null): \GitElephant\Objects\Branch
     {
         $repository
             ->getCaller()
@@ -96,7 +96,7 @@ class Branch extends NodeObject implements TreeishInterface
      * @throws \InvalidArgumentException
      * @return Branch
      */
-    public static function createFromOutputLine(Repository $repository, string $outputLine)
+    public static function createFromOutputLine(Repository $repository, string $outputLine): \GitElephant\Objects\Branch
     {
         $matches = static::getMatches($outputLine);
         $branch = new self($repository, $matches[1]);
@@ -114,13 +114,9 @@ class Branch extends NodeObject implements TreeishInterface
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Branch
      */
-    public static function checkout(Repository $repository, $name, $create = false)
+    public static function checkout(Repository $repository, $name, $create = false): \GitElephant\Objects\Branch
     {
-        if ($create) {
-            $branch = self::create($repository, $name);
-        } else {
-            $branch = new self($repository, $name);
-        }
+        $branch = $create ? self::create($repository, $name) : new self($repository, $name);
 
         $repository->checkout($branch);
 
@@ -175,7 +171,7 @@ class Branch extends NodeObject implements TreeishInterface
      *
      * @throws \InvalidArgumentException
      */
-    public function parseOutputLine(string $branchString)
+    public function parseOutputLine(string $branchString): void
     {
         if (preg_match('/^\* (.*)/', $branchString, $matches)) {
             $this->current = true;
@@ -198,7 +194,7 @@ class Branch extends NodeObject implements TreeishInterface
      * @throws \InvalidArgumentException
      * @return array
      */
-    public static function getMatches(string $branchString)
+    public static function getMatches(string $branchString): array
     {
         $branchString = trim($branchString);
 
@@ -224,7 +220,7 @@ class Branch extends NodeObject implements TreeishInterface
      *
      * @return string the sha
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getSha();
     }
@@ -234,7 +230,7 @@ class Branch extends NodeObject implements TreeishInterface
      *
      * @param string $name the branch name
      */
-    public function setName(string $name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
@@ -244,7 +240,7 @@ class Branch extends NodeObject implements TreeishInterface
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -254,7 +250,7 @@ class Branch extends NodeObject implements TreeishInterface
      *
      * @param string $sha the sha of the branch
      */
-    public function setSha(string $sha)
+    public function setSha(string $sha): void
     {
         $this->sha = $sha;
     }
@@ -264,7 +260,7 @@ class Branch extends NodeObject implements TreeishInterface
      *
      * @return string
      */
-    public function getSha()
+    public function getSha(): string
     {
         return $this->sha;
     }
@@ -274,7 +270,7 @@ class Branch extends NodeObject implements TreeishInterface
      *
      * @param bool $current whether if the branch is the current or not
      */
-    public function setCurrent(bool $current)
+    public function setCurrent(bool $current): void
     {
         $this->current = $current;
     }
@@ -284,7 +280,7 @@ class Branch extends NodeObject implements TreeishInterface
      *
      * @return bool
      */
-    public function getCurrent()
+    public function getCurrent(): bool
     {
         return $this->current;
     }
@@ -294,7 +290,7 @@ class Branch extends NodeObject implements TreeishInterface
      *
      * @param string $comment the branch comment
      */
-    public function setComment(string $comment)
+    public function setComment(string $comment): void
     {
         $this->comment = $comment;
     }
@@ -304,7 +300,7 @@ class Branch extends NodeObject implements TreeishInterface
      *
      * @return string
      */
-    public function getComment()
+    public function getComment(): string
     {
         return $this->comment;
     }
@@ -314,7 +310,7 @@ class Branch extends NodeObject implements TreeishInterface
      *
      * @param string $fullRef full git reference of the branch
      */
-    public function setFullRef(string $fullRef)
+    public function setFullRef(string $fullRef): void
     {
         $this->fullRef = $fullRef;
     }
@@ -324,7 +320,7 @@ class Branch extends NodeObject implements TreeishInterface
      *
      * @return string
      */
-    public function getFullRef()
+    public function getFullRef(): string
     {
         return $this->fullRef;
     }

--- a/src/GitElephant/Objects/Commit.php
+++ b/src/GitElephant/Objects/Commit.php
@@ -128,7 +128,7 @@ class Commit implements TreeishInterface, \Countable
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Commit
      */
-    public static function create(Repository $repository, string $message, bool $stageAll = false, $author = null)
+    public static function create(Repository $repository, string $message, bool $stageAll = false, $author = null): \GitElephant\Objects\Commit
     {
         $repository->getCaller()->execute(MainCommand::getInstance($repository)->commit($message, $stageAll, $author));
 
@@ -145,7 +145,7 @@ class Commit implements TreeishInterface, \Countable
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Commit
      */
-    public static function pick(Repository $repository, $treeish = null)
+    public static function pick(Repository $repository, $treeish = null): \GitElephant\Objects\Commit
     {
         $commit = new self($repository, $treeish);
         $commit->createFromCommand();
@@ -161,7 +161,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @return Commit
      */
-    public static function createFromOutputLines(Repository $repository, array $outputLines)
+    public static function createFromOutputLines(Repository $repository, array $outputLines): \GitElephant\Objects\Commit
     {
         $commit = new self($repository);
         $commit->parseOutputLines($outputLines);
@@ -174,7 +174,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @see ShowCommand::commitInfo
      */
-    public function createFromCommand()
+    public function createFromCommand(): void
     {
         $command = ShowCommand::getInstance($this->getRepository())->showCommit($this->ref);
         $outputLines = $this->getCaller()->execute($command, true, $this->getRepository()->getPath())->getOutputLines();
@@ -186,7 +186,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @see BranchCommand::contains
      */
-    public function getContainedIn()
+    public function getContainedIn(): array
     {
         $command = BranchCommand::getInstance($this->getRepository())->contains($this->getSha());
 
@@ -202,14 +202,14 @@ class Commit implements TreeishInterface, \Countable
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         $command = RevListCommand::getInstance($this->getRepository())->commitPath($this);
 
         return count($this->getCaller()->execute($command)->getOutputLines(true));
     }
 
-    public function getDiff()
+    public function getDiff(): \GitElephant\Objects\Diff\Diff
     {
         return $this->getRepository()->getDiff($this);
     }
@@ -219,7 +219,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @param array $outputLines output lines
      */
-    private function parseOutputLines($outputLines)
+    private function parseOutputLines($outputLines): void
     {
         $message = [];
         foreach ($outputLines as $line) {
@@ -269,9 +269,9 @@ class Commit implements TreeishInterface, \Countable
      *
      * @return bool
      */
-    public function isRoot()
+    public function isRoot(): bool
     {
-        return count($this->parents) == 0;
+        return (is_countable($this->parents) ? count($this->parents) : 0) === 0;
     }
 
     /**
@@ -279,7 +279,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @return string the sha
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->sha;
     }
@@ -287,7 +287,7 @@ class Commit implements TreeishInterface, \Countable
     /**
      * @return \GitElephant\Command\Caller\Caller
      */
-    private function getCaller()
+    private function getCaller(): \GitElephant\Command\Caller\Caller
     {
         return $this->getRepository()->getCaller();
     }
@@ -297,7 +297,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @param \GitElephant\Repository $repository repository variable
      */
-    public function setRepository($repository)
+    public function setRepository($repository): void
     {
         $this->repository = $repository;
     }
@@ -307,7 +307,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @return \GitElephant\Repository
      */
-    public function getRepository()
+    public function getRepository(): \GitElephant\Repository
     {
         return $this->repository;
     }
@@ -317,7 +317,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @return Author
      */
-    public function getAuthor()
+    public function getAuthor(): \GitElephant\Objects\Author
     {
         return $this->author;
     }
@@ -327,7 +327,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @return Author
      */
-    public function getCommitter()
+    public function getCommitter(): \GitElephant\Objects\Author
     {
         return $this->committer;
     }
@@ -337,7 +337,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @return \GitElephant\Objects\Commit\Message
      */
-    public function getMessage()
+    public function getMessage(): \GitElephant\Objects\Commit\Message
     {
         return $this->message;
     }
@@ -347,7 +347,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @return mixed
      */
-    public function getParents()
+    public function getParents(): array
     {
         return $this->parents;
     }
@@ -359,7 +359,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @return mixed
      */
-    public function getSha(bool $short = false)
+    public function getSha(bool $short = false): string
     {
         return $short ? substr($this->sha, 0, 7) : $this->sha;
     }
@@ -369,7 +369,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @return mixed
      */
-    public function getTree()
+    public function getTree(): string
     {
         return $this->tree;
     }
@@ -379,7 +379,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @return mixed
      */
-    public function getDatetimeAuthor()
+    public function getDatetimeAuthor(): \DateTime
     {
         return $this->datetimeAuthor;
     }
@@ -389,7 +389,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @return \DateTime
      */
-    public function getDatetimeCommitter()
+    public function getDatetimeCommitter(): \Datetime
     {
         return $this->datetimeCommitter;
     }
@@ -404,7 +404,7 @@ class Commit implements TreeishInterface, \Countable
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return array
      */
-    public function revParse(array $options = [])
+    public function revParse(array $options = []): array
     {
         $c = RevParseCommand::getInstance()->revParse($this, $options);
         $caller = $this->repository->getCaller();
@@ -421,7 +421,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @return bool
      */
-    public function tagged()
+    public function tagged(): bool
     {
         $result = false;
 
@@ -441,7 +441,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @return Tag[]
      */
-    public function getTags()
+    public function getTags(): array
     {
         $currentCommitTags = [];
 

--- a/src/GitElephant/Objects/Commit.php
+++ b/src/GitElephant/Objects/Commit.php
@@ -218,7 +218,7 @@ class Commit implements TreeishInterface, \Countable
     /**
      * parse the output of a git command showing a commit
      *
-     * @param array $outputLines output lines
+     * @param Iterable $outputLines output lines
      */
     private function parseOutputLines($outputLines): void
     {

--- a/src/GitElephant/Objects/Commit.php
+++ b/src/GitElephant/Objects/Commit.php
@@ -20,6 +20,7 @@
 namespace GitElephant\Objects;
 
 use \GitElephant\Command\BranchCommand;
+use GitElephant\Command\Caller\CallerInterface;
 use \GitElephant\Command\MainCommand;
 use \GitElephant\Command\RevListCommand;
 use \GitElephant\Command\RevParseCommand;
@@ -285,9 +286,9 @@ class Commit implements TreeishInterface, \Countable
     }
 
     /**
-     * @return \GitElephant\Command\Caller\Caller
+     * @return CallerInterface
      */
-    private function getCaller(): \GitElephant\Command\Caller\Caller
+    private function getCaller(): CallerInterface
     {
         return $this->getRepository()->getCaller();
     }
@@ -297,7 +298,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @param \GitElephant\Repository $repository repository variable
      */
-    public function setRepository($repository): void
+    public function setRepository(Repository $repository): void
     {
         $this->repository = $repository;
     }
@@ -345,7 +346,7 @@ class Commit implements TreeishInterface, \Countable
     /**
      * parent getter
      *
-     * @return mixed
+     * @return array
      */
     public function getParents(): array
     {
@@ -357,7 +358,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @param bool $short short version
      *
-     * @return mixed
+     * @return string
      */
     public function getSha(bool $short = false): string
     {
@@ -367,7 +368,7 @@ class Commit implements TreeishInterface, \Countable
     /**
      * tree getter
      *
-     * @return mixed
+     * @return string
      */
     public function getTree(): string
     {
@@ -377,7 +378,7 @@ class Commit implements TreeishInterface, \Countable
     /**
      * datetimeAuthor getter
      *
-     * @return mixed
+     * @return \DateTime
      */
     public function getDatetimeAuthor(): \DateTime
     {
@@ -389,7 +390,7 @@ class Commit implements TreeishInterface, \Countable
      *
      * @return \DateTime
      */
-    public function getDatetimeCommitter(): \Datetime
+    public function getDatetimeCommitter(): \DateTime
     {
         return $this->datetimeCommitter;
     }

--- a/src/GitElephant/Objects/Commit/Message.php
+++ b/src/GitElephant/Objects/Commit/Message.php
@@ -53,7 +53,7 @@ class Message
      *
      * @return string|null
      */
-    public function getShortMessage()
+    public function getShortMessage(): ?string
     {
         return $this->toString();
     }
@@ -63,7 +63,7 @@ class Message
      *
      * @return string|null
      */
-    public function getFullMessage()
+    public function getFullMessage(): ?string
     {
         return $this->toString(true);
     }
@@ -77,7 +77,7 @@ class Message
      */
     public function toString(bool $full = false)
     {
-        if (count($this->message) == 0) {
+        if ((is_countable($this->message) ? count($this->message) : 0) === 0) {
             return null;
         }
 
@@ -93,7 +93,7 @@ class Message
      *
      * @return string|null
      */
-    public function __toString()
+    public function __toString(): ?string
     {
         return $this->toString();
     }

--- a/src/GitElephant/Objects/Diff/Diff.php
+++ b/src/GitElephant/Objects/Diff/Diff.php
@@ -63,7 +63,7 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Diff
      */
-    public static function create(Repository $repository, $commit1 = null, $commit2 = null, string $path = null)
+    public static function create(Repository $repository, $commit1 = null, $commit2 = null, string $path = null): \GitElephant\Objects\Diff\Diff
     {
         $commit = new self($repository);
         $commit->createFromCommand($commit1, $commit2, $path);
@@ -99,7 +99,7 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @see ShowCommand::commitInfo
      */
-    public function createFromCommand($commit1 = null, $commit2 = null, $path = null)
+    public function createFromCommand($commit1 = null, $commit2 = null, $path = null): void
     {
         if (null === $commit1) {
             $commit1 = $this->getRepository()->getCommit();
@@ -133,7 +133,7 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
      *
      * @throws \InvalidArgumentException
      */
-    private function parseOutputLines(array $outputLines)
+    private function parseOutputLines(array $outputLines): void
     {
         $this->diffObjects = [];
         $splitArray = Utilities::pregSplitArray($outputLines, '/^diff --git SRC\/(.*) DST\/(.*)$/');
@@ -145,7 +145,7 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
     /**
      * @return \GitElephant\Command\Caller\Caller
      */
-    private function getCaller()
+    private function getCaller(): \GitElephant\Command\Caller\Caller
     {
         return $this->getRepository()->getCaller();
     }
@@ -155,7 +155,7 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
      *
      * @param \GitElephant\Repository $repository the repository variable
      */
-    public function setRepository(Repository $repository)
+    public function setRepository(Repository $repository): void
     {
         $this->repository = $repository;
     }
@@ -165,7 +165,7 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
      *
      * @return \GitElephant\Repository
      */
-    public function getRepository()
+    public function getRepository(): \GitElephant\Repository
     {
         return $this->repository;
     }
@@ -177,7 +177,7 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->diffObjects[$offset]);
     }
@@ -200,7 +200,7 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
      * @param int   $offset offset
      * @param mixed $value  value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->diffObjects[] = $value;
@@ -214,7 +214,7 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
      *
      * @param int $offset offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->diffObjects[$offset]);
     }
@@ -224,9 +224,9 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int|void
      */
-    public function count()
+    public function count(): int
     {
-        return count($this->diffObjects);
+        return is_countable($this->diffObjects) ? count($this->diffObjects) : 0;
     }
 
     /**
@@ -242,7 +242,7 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
     /**
      * Iterator interface
      */
-    public function next()
+    public function next(): void
     {
         ++$this->position;
     }
@@ -252,7 +252,7 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int
      */
-    public function key()
+    public function key(): int
     {
         return $this->position;
     }
@@ -262,7 +262,7 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         return isset($this->diffObjects[$this->position]);
     }
@@ -270,7 +270,7 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
     /**
      * Iterator interface
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 0;
     }

--- a/src/GitElephant/Objects/Diff/DiffChunk.php
+++ b/src/GitElephant/Objects/Diff/DiffChunk.php
@@ -108,14 +108,14 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
             if (preg_match('/^\+(.*)/', $line)) {
                 $this->lines[] = new DiffChunkLineAdded($new++, preg_replace('/\+(.*)/', ' $1', $line));
                 $destUnchanged++;
-            } else if (preg_match('/^-(.*)/', $line)) {
+            } elseif (preg_match('/^-(.*)/', $line)) {
                 $this->lines[] = new DiffChunkLineDeleted($deleted++, preg_replace('/-(.*)/', ' $1', $line));
                 $originUnchanged++;
-            } else if (preg_match('/^ (.*)/', $line) || $line == '') {
+            } elseif (preg_match('/^ (.*)/', $line) || $line == '') {
                 $this->lines[] = new DiffChunkLineUnchanged($originUnchanged++, $destUnchanged++, $line);
                 $deleted++;
                 $new++;
-            } else if (!preg_match('/\\ No newline at end of file/', $line)) {
+            } elseif (!preg_match('/\\ No newline at end of file/', $line)) {
                 throw new \Exception(sprintf('GitElephant was unable to parse the line %s', $line));
             }
         }
@@ -126,7 +126,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
      *
      * @param string $line a single line
      */
-    private function getLinesNumbers(string $line)
+    private function getLinesNumbers(string $line): void
     {
         $matches = [];
         preg_match('/@@ -(.*) \+(.*) @@?(.*)/', $line, $matches);
@@ -135,7 +135,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
             $this->originStartLine = $matches[1];
             $this->originEndLine = $matches[1];
         } else {
-            list($this->originStartLine, $this->originEndLine) = explode(',', $matches[1]);
+            [$this->originStartLine, $this->originEndLine] = explode(',', $matches[1]);
         }
 
         if (!strpos($matches[2], ',')) {
@@ -143,7 +143,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
             $this->destStartLine = $matches[2];
             $this->destEndLine = $matches[2];
         } else {
-            list($this->destStartLine, $this->destEndLine) = explode(',', $matches[2]);
+            [$this->destStartLine, $this->destEndLine] = explode(',', $matches[2]);
         }
     }
 
@@ -152,7 +152,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int
      */
-    public function getDestStartLine()
+    public function getDestStartLine(): int
     {
         return $this->destStartLine;
     }
@@ -162,7 +162,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int
      */
-    public function getDestEndLine()
+    public function getDestEndLine(): int
     {
         return $this->destEndLine;
     }
@@ -172,7 +172,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int
      */
-    public function getOriginStartLine()
+    public function getOriginStartLine(): int
     {
         return $this->originStartLine;
     }
@@ -182,7 +182,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int
      */
-    public function getOriginEndLine()
+    public function getOriginEndLine(): int
     {
         return $this->originEndLine;
     }
@@ -192,7 +192,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
      *
      * @return string
      */
-    public function getHeaderLine()
+    public function getHeaderLine(): string
     {
         if (null === $this->headerLine) {
             $line = '@@';
@@ -211,7 +211,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
      *
      * @return array
      */
-    public function getLines()
+    public function getLines(): array
     {
         return $this->lines;
     }
@@ -223,7 +223,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->lines[$offset]);
     }
@@ -246,7 +246,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
      * @param int   $offset offset
      * @param mixed $value  value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->lines[] = $value;
@@ -260,7 +260,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
      *
      * @param int $offset offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->lines[$offset]);
     }
@@ -270,9 +270,9 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int|void
      */
-    public function count()
+    public function count(): int
     {
-        return count($this->lines);
+        return is_countable($this->lines) ? count($this->lines) : 0;
     }
 
     /**
@@ -288,7 +288,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
     /**
      * Iterator interface
      */
-    public function next()
+    public function next(): void
     {
         ++$this->position;
     }
@@ -298,7 +298,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int
      */
-    public function key()
+    public function key(): int
     {
         return $this->position;
     }
@@ -308,7 +308,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         return isset($this->lines[$this->position]);
     }
@@ -316,7 +316,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
     /**
      * Iterator interface
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 0;
     }

--- a/src/GitElephant/Objects/Diff/DiffChunkLine.php
+++ b/src/GitElephant/Objects/Diff/DiffChunkLine.php
@@ -49,7 +49,7 @@ abstract class DiffChunkLine
      *
      * @return string the line content
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getContent();
     }
@@ -59,7 +59,7 @@ abstract class DiffChunkLine
      *
      * @param string $type line type
      */
-    public function setType(string $type)
+    public function setType(string $type): void
     {
         $this->type = $type;
     }
@@ -69,7 +69,7 @@ abstract class DiffChunkLine
      *
      * @return mixed
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
@@ -79,7 +79,7 @@ abstract class DiffChunkLine
      *
      * @param string $content line content
      */
-    public function setContent(string $content)
+    public function setContent(string $content): void
     {
         $this->content = $content;
     }
@@ -89,7 +89,7 @@ abstract class DiffChunkLine
      *
      * @return mixed
      */
-    public function getContent()
+    public function getContent(): string
     {
         return $this->content;
     }

--- a/src/GitElephant/Objects/Diff/DiffChunkLineAdded.php
+++ b/src/GitElephant/Objects/Diff/DiffChunkLineAdded.php
@@ -44,7 +44,7 @@ class DiffChunkLineAdded extends DiffChunkLineChanged
      *
      * @return int
      */
-    public function getOriginNumber()
+    public function getOriginNumber(): int
     {
         return '';
     }

--- a/src/GitElephant/Objects/Diff/DiffChunkLineChanged.php
+++ b/src/GitElephant/Objects/Diff/DiffChunkLineChanged.php
@@ -38,7 +38,7 @@ abstract class DiffChunkLineChanged extends DiffChunkLine
      *
      * @param int $number line number
      */
-    public function setNumber(int $number)
+    public function setNumber(int $number): void
     {
         $this->number = $number;
     }
@@ -48,7 +48,7 @@ abstract class DiffChunkLineChanged extends DiffChunkLine
      *
      * @return int
      */
-    public function getNumber()
+    public function getNumber(): int
     {
         return $this->number;
     }
@@ -58,7 +58,7 @@ abstract class DiffChunkLineChanged extends DiffChunkLine
      *
      * @return int
      */
-    public function getOriginNumber()
+    public function getOriginNumber(): int
     {
         return $this->getNumber();
     }
@@ -68,7 +68,7 @@ abstract class DiffChunkLineChanged extends DiffChunkLine
      *
      * @return int
      */
-    public function getDestNumber()
+    public function getDestNumber(): int
     {
         return $this->getNumber();
     }

--- a/src/GitElephant/Objects/Diff/DiffChunkLineDeleted.php
+++ b/src/GitElephant/Objects/Diff/DiffChunkLineDeleted.php
@@ -44,7 +44,7 @@ class DiffChunkLineDeleted extends DiffChunkLineChanged
      *
      * @return int
      */
-    public function getDestNumber()
+    public function getDestNumber(): int
     {
         return '';
     }

--- a/src/GitElephant/Objects/Diff/DiffChunkLineUnchanged.php
+++ b/src/GitElephant/Objects/Diff/DiffChunkLineUnchanged.php
@@ -62,7 +62,7 @@ class DiffChunkLineUnchanged extends DiffChunkLine
      *
      * @param int $number line number
      */
-    public function setOriginNumber(int $number)
+    public function setOriginNumber(int $number): void
     {
         $this->originNumber = $number;
     }
@@ -72,7 +72,7 @@ class DiffChunkLineUnchanged extends DiffChunkLine
      *
      * @return int
      */
-    public function getOriginNumber()
+    public function getOriginNumber(): int
     {
         return $this->originNumber;
     }
@@ -82,7 +82,7 @@ class DiffChunkLineUnchanged extends DiffChunkLine
      *
      * @param int $number line number
      */
-    public function setDestNumber(int $number)
+    public function setDestNumber(int $number): void
     {
         $this->destNumber = $number;
     }
@@ -92,7 +92,7 @@ class DiffChunkLineUnchanged extends DiffChunkLine
      *
      * @return int
      */
-    public function getDestNumber()
+    public function getDestNumber(): int
     {
         return $this->destNumber;
     }

--- a/src/GitElephant/Objects/Diff/DiffObject.php
+++ b/src/GitElephant/Objects/Diff/DiffObject.php
@@ -116,7 +116,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return mixed
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->originalPath;
     }
@@ -128,7 +128,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @throws \InvalidArgumentException
      */
-    private function findChunks(array $lines)
+    private function findChunks(array $lines): void
     {
         $arrayChunks = Utilities::pregSplitArray(
             $lines,
@@ -144,7 +144,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @param string $line line content
      */
-    private function findPath(string $line)
+    private function findPath(string $line): void
     {
         $matches = [];
         if (preg_match('/^diff --git SRC\/(.*) DST\/(.*)$/', $line, $matches)) {
@@ -158,7 +158,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @param string $line line content
      */
-    private function findMode(string $line)
+    private function findMode(string $line): void
     {
         if (preg_match('/^index (.*)\.\.(.*) (.*)$/', $line)) {
             $this->mode = self::MODE_INDEX;
@@ -182,7 +182,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @param string $line line content
      */
-    private function findSimilarityIndex(string $line)
+    private function findSimilarityIndex(string $line): void
     {
         $matches = [];
         if (preg_match('/^similarity index (.*)\%$/', $line, $matches)) {
@@ -195,7 +195,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return array
      */
-    public function getChunks()
+    public function getChunks(): array
     {
         return $this->chunks;
     }
@@ -205,7 +205,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return string
      */
-    public function getDestinationPath()
+    public function getDestinationPath(): string
     {
         return $this->destinationPath;
     }
@@ -215,7 +215,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return string
      */
-    public function getMode()
+    public function getMode(): string
     {
         return $this->mode;
     }
@@ -225,7 +225,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return string
      */
-    public function getOriginalPath()
+    public function getOriginalPath(): string
     {
         return $this->originalPath;
     }
@@ -235,7 +235,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function hasPathChanged()
+    public function hasPathChanged(): bool
     {
         return ($this->originalPath !== $this->destinationPath);
     }
@@ -246,7 +246,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      * @return int
      * @throws \RuntimeException if not a rename
      */
-    public function getSimilarityIndex()
+    public function getSimilarityIndex(): int
     {
         if ($this->hasPathChanged()) {
             return $this->similarityIndex;
@@ -262,7 +262,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->chunks[$offset]);
     }
@@ -285,7 +285,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      * @param int   $offset offset
      * @param mixed $value  value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->chunks[] = $value;
@@ -299,7 +299,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @param int $offset offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->chunks[$offset]);
     }
@@ -309,9 +309,9 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
-        return count($this->chunks);
+        return is_countable($this->chunks) ? count($this->chunks) : 0;
     }
 
     /**
@@ -327,7 +327,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
     /**
      * Iterator interface
      */
-    public function next()
+    public function next(): void
     {
         ++$this->position;
     }
@@ -337,7 +337,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int
      */
-    public function key()
+    public function key(): int
     {
         return $this->position;
     }
@@ -347,7 +347,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         return isset($this->chunks[$this->position]);
     }
@@ -355,7 +355,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
     /**
      * Iterator interface
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 0;
     }

--- a/src/GitElephant/Objects/Log.php
+++ b/src/GitElephant/Objects/Log.php
@@ -58,7 +58,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
      *
      * @return \GitElephant\Objects\Log
      */
-    public static function createFromOutputLines(Repository $repository, array $outputLines)
+    public static function createFromOutputLines(Repository $repository, array $outputLines): \GitElephant\Objects\Log
     {
         $log = new self($repository);
         $log->parseOutputLines($outputLines);
@@ -104,7 +104,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @see ShowCommand::commitInfo
      */
-    private function createFromCommand($ref, $path = null, int $limit, int $offset = null, bool $firstParent = false)
+    private function createFromCommand($ref, $path = null, int $limit, int $offset = null, bool $firstParent = false): void
     {
         $command = LogCommand::getInstance($this->getRepository())
             ->showLog($ref, $path, $limit, $offset, $firstParent);
@@ -117,7 +117,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
         $this->parseOutputLines($outputLines);
     }
 
-    private function parseOutputLines(array $outputLines)
+    private function parseOutputLines(array $outputLines): void
     {
         $this->commits = [];
         $commits = Utilities::pregSplitFlatArray($outputLines, '/^commit (\w+)$/');
@@ -132,7 +132,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->commits;
     }
@@ -142,7 +142,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
      *
      * @return Commit|null
      */
-    public function first()
+    public function first(): ?\GitElephant\Objects\Commit
     {
         return $this->offsetGet(0);
     }
@@ -152,7 +152,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
      *
      * @return Commit|null
      */
-    public function last()
+    public function last(): ?\GitElephant\Objects\Commit
     {
         return $this->offsetGet($this->count() - 1);
     }
@@ -164,7 +164,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
      *
      * @return Commit|null
      */
-    public function index(int $index)
+    public function index(int $index): ?\GitElephant\Objects\Commit
     {
         return $this->offsetGet($index);
     }
@@ -176,7 +176,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->commits[$offset]);
     }
@@ -188,7 +188,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
      *
      * @return Commit|null
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): ?\GitElephant\Objects\Commit
     {
         return isset($this->commits[$offset]) ? $this->commits[$offset] : null;
     }
@@ -223,7 +223,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->commits);
     }
@@ -233,7 +233,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
      *
      * @return Commit|null
      */
-    public function current()
+    public function current(): ?\GitElephant\Objects\Commit
     {
         return $this->offsetGet($this->position);
     }
@@ -241,7 +241,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
     /**
      * Iterator interface
      */
-    public function next()
+    public function next(): void
     {
         ++$this->position;
     }
@@ -251,7 +251,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int
      */
-    public function key()
+    public function key(): int
     {
         return $this->position;
     }
@@ -261,7 +261,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->offsetExists($this->position);
     }
@@ -269,7 +269,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
     /**
      * Iterator interface
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 0;
     }
@@ -279,7 +279,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
      *
      * @param \GitElephant\Repository $repository the repository variable
      */
-    public function setRepository(Repository $repository)
+    public function setRepository(Repository $repository): void
     {
         $this->repository = $repository;
     }
@@ -289,7 +289,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
      *
      * @return \GitElephant\Repository
      */
-    public function getRepository()
+    public function getRepository(): \GitElephant\Repository
     {
         return $this->repository;
     }

--- a/src/GitElephant/Objects/Log.php
+++ b/src/GitElephant/Objects/Log.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * GitElephant - An abstraction layer for git written in PHP
  * Copyright (C) 2013  Matteo Giachino
@@ -83,8 +84,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
         int $limit = 15,
         int $offset = null,
         bool $firstParent = false
-    )
-    {
+    ) {
         $this->repository = $repository;
         $this->createFromCommand($ref, $path, $limit, $offset, $firstParent);
     }
@@ -104,7 +104,7 @@ class Log implements \ArrayAccess, \Countable, \Iterator
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @see ShowCommand::commitInfo
      */
-    private function createFromCommand($ref, $path = null, int $limit, int $offset = null, bool $firstParent = false): void
+    private function createFromCommand($ref, $path = null, int $limit = null, int $offset = null, bool $firstParent = false): void
     {
         $command = LogCommand::getInstance($this->getRepository())
             ->showLog($ref, $path, $limit, $offset, $firstParent);
@@ -123,7 +123,11 @@ class Log implements \ArrayAccess, \Countable, \Iterator
         $commits = Utilities::pregSplitFlatArray($outputLines, '/^commit (\w+)$/');
 
         foreach ($commits as $commitOutputLines) {
-            $this->commits[] = Commit::createFromOutputLines($this->getRepository(), $commitOutputLines);
+            if (is_string($commitOutputLines)) {
+                $this->commits[] = Commit::createFromOutputLines($this->getRepository(), [$commitOutputLines]);
+            } elseif (is_iterable($commitOutputLines)) {
+                $this->commits[] = Commit::createFromOutputLines($this->getRepository(), $commitOutputLines);
+            }
         }
     }
 

--- a/src/GitElephant/Objects/LogRange.php
+++ b/src/GitElephant/Objects/LogRange.php
@@ -68,8 +68,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
         int $limit = 15,
         int $offset = null,
         bool $firstParent = false
-    )
-    {
+    ) {
         $this->repository = $repository;
         $this->createFromCommand($refStart, $refEnd, $path, $limit, $offset, $firstParent);
     }
@@ -97,8 +96,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
         int $limit = 15,
         int $offset = null,
         bool $firstParent = false
-    ): void
-    {
+    ): void {
         $command = LogRangeCommand::getInstance($this->getRepository())->showLog(
             $refStart,
             $refEnd,

--- a/src/GitElephant/Objects/LogRange.php
+++ b/src/GitElephant/Objects/LogRange.php
@@ -97,7 +97,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
         int $limit = 15,
         int $offset = null,
         bool $firstParent = false
-    )
+    ): void
     {
         $command = LogRangeCommand::getInstance($this->getRepository())->showLog(
             $refStart,
@@ -116,7 +116,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
         $this->parseOutputLines($outputLines);
     }
 
-    private function parseOutputLines(array $outputLines)
+    private function parseOutputLines(array $outputLines): void
     {
         $commitLines = null;
         $this->rangeCommits = [];
@@ -140,7 +140,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->rangeCommits;
     }
@@ -150,7 +150,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
      *
      * @return Commit|null
      */
-    public function first()
+    public function first(): ?\GitElephant\Objects\Commit
     {
         return $this->offsetGet(0);
     }
@@ -160,7 +160,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
      *
      * @return Commit|null
      */
-    public function last()
+    public function last(): ?\GitElephant\Objects\Commit
     {
         return $this->offsetGet($this->count() - 1);
     }
@@ -172,7 +172,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
      *
      * @return Commit|null
      */
-    public function index(int $index)
+    public function index(int $index): ?\GitElephant\Objects\Commit
     {
         return $this->offsetGet($index);
     }
@@ -184,7 +184,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->rangeCommits[$offset]);
     }
@@ -196,7 +196,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
      *
      * @return Commit|null
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): ?\GitElephant\Objects\Commit
     {
         return isset($this->rangeCommits[$offset]) ? $this->rangeCommits[$offset] : null;
     }
@@ -231,7 +231,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int|void
      */
-    public function count()
+    public function count(): int
     {
         return count($this->rangeCommits);
     }
@@ -241,7 +241,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
      *
      * @return Commit|null
      */
-    public function current()
+    public function current(): ?\GitElephant\Objects\Commit
     {
         return $this->offsetGet($this->position);
     }
@@ -249,7 +249,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
     /**
      * Iterator interface
      */
-    public function next()
+    public function next(): void
     {
         ++$this->position;
     }
@@ -259,7 +259,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int
      */
-    public function key()
+    public function key(): int
     {
         return $this->position;
     }
@@ -269,7 +269,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->offsetExists($this->position);
     }
@@ -277,7 +277,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
     /**
      * Iterator interface
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 0;
     }
@@ -287,7 +287,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
      *
      * @param \GitElephant\Repository $repository the repository variable
      */
-    public function setRepository(Repository $repository)
+    public function setRepository(Repository $repository): void
     {
         $this->repository = $repository;
     }
@@ -297,7 +297,7 @@ class LogRange implements \ArrayAccess, \Countable, \Iterator
      *
      * @return \GitElephant\Repository
      */
-    public function getRepository()
+    public function getRepository(): \GitElephant\Repository
     {
         return $this->repository;
     }

--- a/src/GitElephant/Objects/NodeObject.php
+++ b/src/GitElephant/Objects/NodeObject.php
@@ -169,8 +169,7 @@ class NodeObject implements TreeishInterface
         string $size,
         string $name,
         string $path
-    )
-    {
+    ) {
         $this->repository = $repository;
         $this->permissions = $permissions;
         $this->type = $type;

--- a/src/GitElephant/Objects/NodeObject.php
+++ b/src/GitElephant/Objects/NodeObject.php
@@ -121,7 +121,7 @@ class NodeObject implements TreeishInterface
      *
      * @return array
      */
-    public static function getLineSlices(string $line)
+    public static function getLineSlices(string $line): array
     {
         preg_match('/^(\d+) (\w+) ([a-z0-9]+) +(\d+|-)\t(.*)$/', $line, $matches);
         $permissions = $matches[1];
@@ -185,7 +185,7 @@ class NodeObject implements TreeishInterface
      *
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return (string)$this->name;
     }
@@ -207,7 +207,7 @@ class NodeObject implements TreeishInterface
      *
      * @return string|null
      */
-    public function getExtension()
+    public function getExtension(): ?string
     {
         $pos = strrpos($this->name, '.');
         if ($pos === false) {
@@ -222,7 +222,7 @@ class NodeObject implements TreeishInterface
      *
      * @return bool
      */
-    public function isTree()
+    public function isTree(): bool
     {
         return self::TYPE_TREE == $this->getType();
     }
@@ -232,7 +232,7 @@ class NodeObject implements TreeishInterface
      *
      * @return bool
      */
-    public function isLink()
+    public function isLink(): bool
     {
         return self::TYPE_LINK == $this->getType();
     }
@@ -242,7 +242,7 @@ class NodeObject implements TreeishInterface
      *
      * @return bool
      */
-    public function isBlob()
+    public function isBlob(): bool
     {
         return self::TYPE_BLOB == $this->getType();
     }
@@ -252,7 +252,7 @@ class NodeObject implements TreeishInterface
      *
      * @return string
      */
-    public function getFullPath()
+    public function getFullPath(): string
     {
         return rtrim(
             '' == $this->path ? $this->name : $this->path . DIRECTORY_SEPARATOR . $this->name,
@@ -265,7 +265,7 @@ class NodeObject implements TreeishInterface
      *
      * @return string
      */
-    public function getPermissions()
+    public function getPermissions(): string
     {
         return $this->permissions;
     }
@@ -275,7 +275,7 @@ class NodeObject implements TreeishInterface
      *
      * @return string
      */
-    public function getSha()
+    public function getSha(): string
     {
         return $this->sha;
     }
@@ -285,7 +285,7 @@ class NodeObject implements TreeishInterface
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
@@ -295,7 +295,7 @@ class NodeObject implements TreeishInterface
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -305,7 +305,7 @@ class NodeObject implements TreeishInterface
      *
      * @return string
      */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }
@@ -315,7 +315,7 @@ class NodeObject implements TreeishInterface
      *
      * @return string
      */
-    public function getSize()
+    public function getSize(): string
     {
         return $this->size;
     }
@@ -325,7 +325,7 @@ class NodeObject implements TreeishInterface
      *
      * @return Commit
      */
-    public function getLastCommit()
+    public function getLastCommit(): ?\GitElephant\Objects\Commit
     {
         $log = $this->repository->getLog('HEAD', $this->getFullPath(), 1);
 
@@ -342,7 +342,7 @@ class NodeObject implements TreeishInterface
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return array
      */
-    public function revParse(array $options = [])
+    public function revParse(array $options = []): array
     {
         $c = RevParseCommand::getInstance()->revParse($this, $options);
         $caller = $this->repository->getCaller();
@@ -356,7 +356,7 @@ class NodeObject implements TreeishInterface
      *
      * @param \GitElephant\Repository $repository the repository variable
      */
-    public function setRepository(Repository $repository)
+    public function setRepository(Repository $repository): void
     {
         $this->repository = $repository;
     }
@@ -366,7 +366,7 @@ class NodeObject implements TreeishInterface
      *
      * @return \GitElephant\Repository
      */
-    public function getRepository()
+    public function getRepository(): \GitElephant\Repository
     {
         return $this->repository;
     }

--- a/src/GitElephant/Objects/Remote.php
+++ b/src/GitElephant/Objects/Remote.php
@@ -102,7 +102,7 @@ class Remote
      *
      * @return \GitElephant\Objects\Remote
      */
-    public static function pick(Repository $repository, string $name = null, bool $queryRemotes = true)
+    public static function pick(Repository $repository, string $name = null, bool $queryRemotes = true): \GitElephant\Objects\Remote
     {
         return new self($repository, $name, $queryRemotes);
     }
@@ -118,9 +118,9 @@ class Remote
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return array
      */
-    public function getVerboseOutput(RemoteCommand $remoteCmd = null)
+    public function getVerboseOutput(RemoteCommand $remoteCmd = null): array
     {
-        if (!$remoteCmd) {
+        if ($remoteCmd === null) {
             $remoteCmd = RemoteCommand::getInstance($this->repository);
         }
         $command = $remoteCmd->verbose();
@@ -144,9 +144,9 @@ class Remote
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return array
      */
-    public function getShowOutput(string $name = null, RemoteCommand $remoteCmd = null, bool $queryRemotes = true)
+    public function getShowOutput(string $name = null, RemoteCommand $remoteCmd = null, bool $queryRemotes = true): array
     {
-        if (!$remoteCmd) {
+        if ($remoteCmd === null) {
             $remoteCmd = RemoteCommand::getInstance($this->repository);
         }
         $command = $remoteCmd->show($name, $queryRemotes);
@@ -168,7 +168,7 @@ class Remote
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return \GitElephant\Objects\Remote
      */
-    private function createFromCommand(bool $queryRemotes = true)
+    private function createFromCommand(bool $queryRemotes = true): self
     {
         $outputLines = $this->getVerboseOutput();
         $list = [];
@@ -202,7 +202,7 @@ class Remote
         $name = array_shift($remoteDetails);
         $name = (is_string($name)) ? trim($name) : '';
         $name = $this->parseName($name);
-        if (!$name) {
+        if ($name === '') {
             throw new \UnexpectedValueException(sprintf('Invalid data provided for remote detail parsing'));
         }
         $this->name = $name;
@@ -255,7 +255,7 @@ class Remote
      *
      * @return array
      */
-    protected function aggregateBranchDetails($groupLines, $remoteDetails)
+    protected function aggregateBranchDetails($groupLines, $remoteDetails): array
     {
         $configuredRefs = [];
         arsort($groupLines);
@@ -282,7 +282,7 @@ class Remote
                 if (!isset($aggBranches[$branchName])) {
                     $aggBranches[$branchName] = [];
                 }
-                $aggBranches[$branchName] = $aggBranches[$branchName] + $data;
+                $aggBranches[$branchName] += $data;
             }
         }
 
@@ -296,7 +296,7 @@ class Remote
      *
      * @return array
      */
-    public function parseRemoteBranches(array $lines)
+    public function parseRemoteBranches(array $lines): array
     {
         $branches = [];
         $delimiter = ' ';
@@ -320,7 +320,7 @@ class Remote
      *
      * @return array
      */
-    public function parseLocalPullBranches($lines)
+    public function parseLocalPullBranches($lines): array
     {
         $branches = [];
         $delimiter = ' merges with remote ';
@@ -344,7 +344,7 @@ class Remote
      *
      * @return array
      */
-    public function parseLocalPushRefs($lines)
+    public function parseLocalPushRefs($lines): array
     {
         $branches = [];
         $delimiter = ' pushes to ';
@@ -388,11 +388,11 @@ class Remote
      * @throws \InvalidArgumentException
      * @return array
      */
-    public static function getMatches($remoteString)
+    public static function getMatches($remoteString): array
     {
         $matches = [];
         preg_match('/^(\S+)\s*(\S[^\( ]+)\s*\((.+)\)$/', trim($remoteString), $matches);
-        if (!count($matches)) {
+        if (count($matches) === 0) {
             throw new \InvalidArgumentException(sprintf('the remote string is not valid: %s', $remoteString));
         }
 
@@ -404,7 +404,7 @@ class Remote
      *
      * @return string the named remote
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getName();
     }
@@ -414,7 +414,7 @@ class Remote
      *
      * @param string $name the remote name
      */
-    public function setName($name)
+    public function setName($name): void
     {
         $this->name = $name;
     }
@@ -424,7 +424,7 @@ class Remote
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -434,7 +434,7 @@ class Remote
      *
      * @return string
      */
-    public function getFetchURL()
+    public function getFetchURL(): string
     {
         return $this->fetchURL;
     }
@@ -444,7 +444,7 @@ class Remote
      *
      * @param string $url the fetch url
      */
-    public function setFetchURL($url)
+    public function setFetchURL($url): void
     {
         $this->fetchURL = $url;
     }
@@ -454,7 +454,7 @@ class Remote
      *
      * @return string
      */
-    public function getPushURL()
+    public function getPushURL(): string
     {
         return $this->pushURL;
     }
@@ -464,7 +464,7 @@ class Remote
      *
      * @param string $url the push url
      */
-    public function setPushURL($url)
+    public function setPushURL($url): void
     {
         $this->pushURL = $url;
     }
@@ -474,7 +474,7 @@ class Remote
      *
      * @return string
      */
-    public function getRemoteHEAD()
+    public function getRemoteHEAD(): string
     {
         return $this->remoteHEAD;
     }
@@ -484,7 +484,7 @@ class Remote
      *
      * @param string $branchName
      */
-    public function setRemoteHEAD($branchName)
+    public function setRemoteHEAD($branchName): void
     {
         $this->remoteHEAD = $branchName;
     }
@@ -494,7 +494,7 @@ class Remote
      *
      * @return array
      */
-    public function getBranches()
+    public function getBranches(): array
     {
         return $this->branches;
     }
@@ -504,7 +504,7 @@ class Remote
      *
      * @param array $branches
      */
-    public function setBranches(Array $branches)
+    public function setBranches(Array $branches): void
     {
         $this->branches = $branches;
     }

--- a/src/GitElephant/Objects/Tag.php
+++ b/src/GitElephant/Objects/Tag.php
@@ -67,7 +67,7 @@ class Tag extends NodeObject
         string $name,
         $startPoint = null,
         string $message = null
-    )
+    ): ?\GitElephant\Objects\Tag
     {
         $repository
             ->getCaller()
@@ -88,7 +88,7 @@ class Tag extends NodeObject
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Tag
      */
-    public static function createFromOutputLines(Repository $repository, array $outputLines, string $name)
+    public static function createFromOutputLines(Repository $repository, array $outputLines, string $name): \GitElephant\Objects\Tag
     {
         $tag = new self($repository, $name);
         $tag->parseOutputLines($outputLines);
@@ -122,7 +122,7 @@ class Tag extends NodeObject
      *
      * @return \GitElephant\Objects\Tag
      */
-    public static function pick(Repository $repository, string $name)
+    public static function pick(Repository $repository, string $name): \GitElephant\Objects\Tag
     {
         return new self($repository, $name);
     }
@@ -130,7 +130,7 @@ class Tag extends NodeObject
     /**
      * deletes the tag
      */
-    public function delete()
+    public function delete(): void
     {
         $this->repository
             ->getCaller()
@@ -142,7 +142,7 @@ class Tag extends NodeObject
      *
      * @see ShowCommand::commitInfo
      */
-    private function createFromCommand()
+    private function createFromCommand(): void
     {
         $command = TagCommand::getInstance($this->getRepository())->listTags();
         $outputLines = $this->getCaller()->execute($command, true, $this->getRepository()->getPath())->getOutputLines();
@@ -185,7 +185,7 @@ class Tag extends NodeObject
      *
      * @return string the sha
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getSha();
     }
@@ -193,7 +193,7 @@ class Tag extends NodeObject
     /**
      * @return \GitElephant\Command\Caller\Caller
      */
-    private function getCaller()
+    private function getCaller(): \GitElephant\Command\Caller\Caller
     {
         return $this->getRepository()->getCaller();
     }
@@ -203,7 +203,7 @@ class Tag extends NodeObject
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -213,7 +213,7 @@ class Tag extends NodeObject
      *
      * @return string
      */
-    public function getFullRef()
+    public function getFullRef(): string
     {
         return $this->fullRef;
     }
@@ -223,7 +223,7 @@ class Tag extends NodeObject
      *
      * @param string $sha sha
      */
-    public function setSha(string $sha)
+    public function setSha(string $sha): void
     {
         $this->sha = $sha;
     }
@@ -233,7 +233,7 @@ class Tag extends NodeObject
      *
      * @return string
      */
-    public function getSha()
+    public function getSha(): string
     {
         return $this->sha;
     }

--- a/src/GitElephant/Objects/Tag.php
+++ b/src/GitElephant/Objects/Tag.php
@@ -67,8 +67,7 @@ class Tag extends NodeObject
         string $name,
         $startPoint = null,
         string $message = null
-    ): ?\GitElephant\Objects\Tag
-    {
+    ): ?\GitElephant\Objects\Tag {
         $repository
             ->getCaller()
             ->execute(TagCommand::getInstance($repository)->create($name, $startPoint, $message));

--- a/src/GitElephant/Objects/Tree.php
+++ b/src/GitElephant/Objects/Tree.php
@@ -81,7 +81,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return \GitElephant\Objects\Tree
      */
-    public static function createFromOutputLines(Repository $repository, array $outputLines)
+    public static function createFromOutputLines(Repository $repository, array $outputLines): \GitElephant\Objects\Tree
     {
         $tree = new self($repository);
         $tree->parseOutputLines($outputLines);
@@ -94,7 +94,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @see LsTreeCommand::tree
      */
-    private function createFromCommand()
+    private function createFromCommand(): void
     {
         $command = LsTreeCommand::getInstance($this->getRepository())->tree($this->ref, $this->subject);
         $outputLines = $this->getCaller()->execute($command)->getOutputLines(true);
@@ -129,7 +129,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @param array $outputLines output lines
      */
-    private function parseOutputLines(array $outputLines)
+    private function parseOutputLines(array $outputLines): void
     {
         foreach ($outputLines as $line) {
             $this->parseLine($line);
@@ -141,7 +141,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
     /**
      * @return \GitElephant\Command\Caller\Caller
      */
-    private function getCaller()
+    private function getCaller(): \GitElephant\Command\Caller\Caller
     {
         return $this->getRepository()->getCaller();
     }
@@ -151,7 +151,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return null|string
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         if ($this->isRoot()) {
             return null;
@@ -165,7 +165,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function isRoot()
+    public function isRoot(): bool
     {
         return null === $this->subject;
     }
@@ -175,7 +175,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function isBlob()
+    public function isBlob(): bool
     {
         return isset($this->blob);
     }
@@ -185,7 +185,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function isBinary()
+    public function isBinary(): bool
     {
         return $this->isRoot() ? false : NodeObject::TYPE_BLOB === $this->subject->getType();
     }
@@ -199,7 +199,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return string
      */
-    public function getBinaryData()
+    public function getBinaryData(): string
     {
         $cmd = CatFileCommand::getInstance($this->getRepository())->content($this->getSubject(), $this->ref);
 
@@ -217,7 +217,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return array
      */
-    public function getBreadcrumb()
+    public function getBreadcrumb(): array
     {
         $bc = [];
         if (!$this->isRoot()) {
@@ -247,7 +247,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return mixed
      */
-    private function scanPathsForBlob(array $outputLines)
+    private function scanPathsForBlob(array $outputLines): void
     {
         // no children, empty folder or blob!
         if (count($this->children) > 0) {
@@ -276,16 +276,16 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int
      */
-    private function sortChildren(NodeObject $a, NodeObject $b)
+    private function sortChildren(NodeObject $a, NodeObject $b): int
     {
-        if ($a->getType() == $b->getType()) {
+        if ($a->getType() === $b->getType()) {
             $names = [$a->getName(), $b->getName()];
             sort($names);
 
             return ($a->getName() === $names[0]) ? -1 : 1;
         }
 
-        return $a->getType() == NodeObject::TYPE_TREE || $b->getType() == NodeObject::TYPE_BLOB ? -1 : 1;
+        return $a->getType() === NodeObject::TYPE_TREE || $b->getType() === NodeObject::TYPE_BLOB ? -1 : 1;
     }
 
     /**
@@ -295,9 +295,9 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return mixed
      */
-    private function parseLine($line)
+    private function parseLine($line): void
     {
-        if ($line == '') {
+        if ($line === '') {
             return;
         }
 
@@ -349,7 +349,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      * @throws \RuntimeException
      * @return Commit\Message
      */
-    public function getLastCommitMessage($ref = 'master')
+    public function getLastCommitMessage($ref = 'master'): \GitElephant\Objects\Commit\Message
     {
         return $this->getLastCommit($ref)->getMessage();
     }
@@ -362,7 +362,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      * @throws \RuntimeException
      * @return Author
      */
-    public function getLastCommitAuthor($ref = 'master')
+    public function getLastCommitAuthor($ref = 'master'): \GitElephant\Objects\Author
     {
         return $this->getLastCommit($ref)->getAuthor();
     }
@@ -376,7 +376,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Commit
      */
-    public function getLastCommit($ref = 'master')
+    public function getLastCommit($ref = 'master'): ?\GitElephant\Objects\Commit
     {
         if ($this->isRoot()) {
             return $this->getRepository()->getCommit($ref);
@@ -391,7 +391,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return \GitElephant\Objects\NodeObject
      */
-    public function getObject()
+    public function getObject(): ?\GitElephant\Objects\NodeObject
     {
         return $this->isRoot() ? null : $this->getSubject();
     }
@@ -401,7 +401,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return \GitElephant\Objects\NodeObject
      */
-    public function getBlob()
+    public function getBlob(): \GitElephant\Objects\NodeObject
     {
         return $this->blob;
     }
@@ -411,7 +411,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return \GitElephant\Objects\NodeObject
      */
-    public function getSubject()
+    public function getSubject(): \GitElephant\Objects\NodeObject
     {
         return $this->subject;
     }
@@ -421,7 +421,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return string
      */
-    public function getRef()
+    public function getRef(): string
     {
         return $this->ref;
     }
@@ -433,7 +433,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->children[$offset]);
     }
@@ -457,7 +457,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      * @param int   $offset offset
      * @param mixed $value  value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (is_null($offset)) {
             $this->children[] = $value;
@@ -471,7 +471,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @param int $offset offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->children[$offset]);
     }
@@ -481,7 +481,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->children);
     }
@@ -499,7 +499,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
     /**
      * Iterator interface
      */
-    public function next()
+    public function next(): void
     {
         ++$this->position;
     }
@@ -509,7 +509,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return int
      */
-    public function key()
+    public function key(): int
     {
         return $this->position;
     }
@@ -519,7 +519,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         return isset($this->children[$this->position]);
     }
@@ -527,7 +527,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
     /**
      * Iterator interface
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 0;
     }

--- a/src/GitElephant/Repository.php
+++ b/src/GitElephant/Repository.php
@@ -134,7 +134,7 @@ class Repository
      *
      * @return \GitElephant\Repository
      */
-    public static function open($repositoryPath, string $binary = null, $name = null)
+    public static function open($repositoryPath, string $binary = null, $name = null): \GitElephant\Repository
     {
         return new self($repositoryPath, $binary, $name);
     }
@@ -152,7 +152,7 @@ class Repository
      * @throws \Symfony\Component\Filesystem\Exception\IOException
      * @return Repository
      */
-    public static function createFromRemote($git, $repositoryPath = null, string $binary = null, $name = null)
+    public static function createFromRemote($git, $repositoryPath = null, string $binary = null, $name = null): \GitElephant\Repository
     {
         if (null === $repositoryPath) {
             $tempDir = realpath(sys_get_temp_dir());
@@ -181,7 +181,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function init($bare = false)
+    public function init($bare = false): self
     {
         $this->caller->execute(MainCommand::getInstance($this)->init($bare));
 
@@ -199,7 +199,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function stage($path = '.')
+    public function stage($path = '.'): self
     {
         $this->caller->execute(MainCommand::getInstance($this)->add($path));
 
@@ -217,7 +217,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function unstage($path)
+    public function unstage($path): self
     {
         $this->caller->execute(MainCommand::getInstance($this)->unstage($path), true, null, [0, 1]);
 
@@ -237,7 +237,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function move($from, $to)
+    public function move($from, $to): self
     {
         $this->caller->execute(MainCommand::getInstance($this)->move($from, $to));
 
@@ -258,7 +258,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function remove($path, $recursive = false, $force = false)
+    public function remove($path, $recursive = false, $force = false): self
     {
         $this->caller->execute(MainCommand::getInstance($this)->remove($path, $recursive, $force));
 
@@ -279,7 +279,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function commit(string $message, $stageAll = false, $ref = null, $author = null, $allowEmpty = false)
+    public function commit(string $message, $stageAll = false, $ref = null, $author = null, $allowEmpty = false): self
     {
         $currentBranch = null;
         if (!is_null($ref)) {
@@ -308,7 +308,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return array
      */
-    public function revParse(string $arg = null, array $options = [])
+    public function revParse(string $arg = null, array $options = []): array
     {
         $this->caller->execute(RevParseCommand::getInstance()->revParse($arg, $options));
 
@@ -320,7 +320,7 @@ class Repository
      *
      * @return boolean
      */
-    public function isBare()
+    public function isBare(): bool
     {
         $options = [RevParseCommand::OPTION_IS_BARE_REPOSIORY];
         $this->caller->execute(RevParseCommand::getInstance()->revParse(null, $options));
@@ -332,7 +332,7 @@ class Repository
      * @param TreeishInterface|Commit|string $arg
      * @param array                          $options
      */
-    public function reset($arg, $options)
+    public function reset($arg, $options): void
     {
         $this->caller->execute(ResetCommand::getInstance($this)->reset($arg, $options));
     }
@@ -342,7 +342,7 @@ class Repository
      *
      * @return Status
      */
-    public function getStatus()
+    public function getStatus(): \GitElephant\Status\Status
     {
         return Status::get($this);
     }
@@ -350,7 +350,7 @@ class Repository
     /**
      * @return Status
      */
-    public function getWorkingTreeStatus()
+    public function getWorkingTreeStatus(): \GitElephant\Status\Status
     {
         return StatusWorkingTree::get($this);
     }
@@ -358,7 +358,7 @@ class Repository
     /**
      * @return Status
      */
-    public function getIndexStatus()
+    public function getIndexStatus(): \GitElephant\Status\Status
     {
         return StatusIndex::get($this);
     }
@@ -368,7 +368,7 @@ class Repository
      *
      * @return boolean
      */
-    public function isClean()
+    public function isClean(): bool
     {
         return $this->getStatus()->all()->isEmpty();
     }
@@ -378,7 +378,7 @@ class Repository
      *
      * @return boolean
      */
-    public function isDirty()
+    public function isDirty(): bool
     {
         return !$this->isClean();
     }
@@ -392,7 +392,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return array
      */
-    public function getStatusOutput()
+    public function getStatusOutput(): array
     {
         $this->caller->execute(MainCommand::getInstance($this)->status());
 
@@ -409,7 +409,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function createBranch(string $name, $startPoint = null)
+    public function createBranch(string $name, $startPoint = null): self
     {
         Branch::create($this, $name, $startPoint);
 
@@ -429,7 +429,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function deleteBranch(string $name, bool $force = false)
+    public function deleteBranch(string $name, bool $force = false): self
     {
         $this->caller->execute(BranchCommand::getInstance($this)->delete($name, $force));
 
@@ -449,7 +449,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return array
      */
-    public function getBranches(bool $namesOnly = false, bool $all = false)
+    public function getBranches(bool $namesOnly = false, bool $all = false): array
     {
         $branches = [];
         if ($namesOnly) {
@@ -484,7 +484,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Objects\Branch
      */
-    public function getMainBranch()
+    public function getMainBranch(): \GitElephant\Objects\Branch
     {
         $filtered = array_filter(
             $this->getBranches(),
@@ -507,7 +507,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return null|Branch
      */
-    public function getBranch(string $name)
+    public function getBranch(string $name): ?\GitElephant\Objects\Branch
     {
         /** @var Branch $branch */
         foreach ($this->getBranches() as $branch) {
@@ -529,7 +529,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function checkoutAllRemoteBranches($remote = 'origin')
+    public function checkoutAllRemoteBranches($remote = 'origin'): self
     {
         $actualBranch = $this->getMainBranch();
         $actualBranches = $this->getBranches(true, false);
@@ -565,7 +565,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function merge(Branch $branch, string $message = '', string $mode = 'auto')
+    public function merge(Branch $branch, string $message = '', string $mode = 'auto'): self
     {
         $valid_modes = [
             'auto', // deafult git behavior
@@ -603,7 +603,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function createTag(string $name, $startPoint = null, string $message = null)
+    public function createTag(string $name, $startPoint = null, string $message = null): self
     {
         Tag::create($this, $name, $startPoint, $message);
 
@@ -620,7 +620,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function deleteTag($tag)
+    public function deleteTag($tag): self
     {
         if ($tag instanceof Tag) {
             $tag->delete();
@@ -643,7 +643,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function addSubmodule(string $gitUrl, $path = null)
+    public function addSubmodule(string $gitUrl, $path = null): self
     {
         $this->caller->execute(SubmoduleCommand::getInstance($this)->add($gitUrl, $path));
 
@@ -657,7 +657,7 @@ class Repository
      *
      * @return Repository
      */
-    public function initSubmodule($path = null)
+    public function initSubmodule($path = null): self
     {
         $this->caller->execute(SubmoduleCommand::getInstance($this)->init($path));
 
@@ -679,7 +679,7 @@ class Repository
         bool $init = false,
         bool $force = false,
         $path = null
-    ) {
+    ): self {
         $this->caller->execute(SubmoduleCommand::getInstance($this)->update($recursive, $init, $force, $path));
 
         return $this;
@@ -694,7 +694,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return array
      */
-    public function getTags()
+    public function getTags(): array
     {
         $tags = [];
         $this->caller->execute(TagCommand::getInstance($this)->listTags());
@@ -716,7 +716,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Tag|null
      */
-    public function getTag(string $name)
+    public function getTag(string $name): ?\GitElephant\Objects\Tag
     {
         $tagFinderOutput = $this->caller
             ->execute(TagCommand::getInstance()->listTags())
@@ -739,14 +739,14 @@ class Repository
      * @throws \InvalidArgumentException
      * @return Tag|null
      */
-    public function getLastTag()
+    public function getLastTag(): ?\GitElephant\Objects\Tag
     {
         $finder = Finder::create()
             ->files()
             ->in(sprintf('%s/.git/refs/tags', $this->path))
             ->sortByChangedTime();
 
-        if ($finder->count() == 0) {
+        if ($finder->count() === 0) {
             return null;
         }
 
@@ -792,11 +792,9 @@ class Repository
      * @throws \RuntimeException
      * @return Objects\Commit
      */
-    public function getCommit($ref = 'HEAD')
+    public function getCommit($ref = 'HEAD'): \GitElephant\Objects\Commit
     {
-        $commit = Commit::pick($this, $ref);
-
-        return $commit;
+        return Commit::pick($this, $ref);
     }
 
     /**
@@ -808,7 +806,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return int
      */
-    public function countCommits($start = 'HEAD')
+    public function countCommits($start = 'HEAD'): int
     {
         $commit = Commit::pick($this, $start);
 
@@ -832,7 +830,7 @@ class Repository
         int $limit = 10,
         int $offset = null,
         bool $firstParent = false
-    ) {
+    ): \GitElephant\Objects\Log {
         return new Log($this, $ref, $path, $limit, $offset, $firstParent);
     }
 
@@ -883,7 +881,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return \GitElephant\Objects\Log
      */
-    public function getObjectLog(NodeObject $obj, $branch = null, int $limit = 1, int $offset = null)
+    public function getObjectLog(NodeObject $obj, $branch = null, int $limit = 1, int $offset = null): \GitElephant\Objects\Log
     {
         $command = LogCommand::getInstance($this)->showObjectLog($obj, $branch, $limit, $offset);
 
@@ -903,7 +901,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function checkout($ref, bool $create = false)
+    public function checkout($ref, bool $create = false): self
     {
         if ($create && is_null($this->getBranch($ref))) {
             $this->createBranch($ref);
@@ -926,7 +924,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Objects\Tree
      */
-    public function getTree($ref = 'HEAD', $path = null)
+    public function getTree($ref = 'HEAD', $path = null): \GitElephant\Objects\Tree
     {
         if (is_string($path) && '' !== $path) {
             $outputLines = $this
@@ -951,7 +949,7 @@ class Repository
      * @throws \InvalidArgumentException
      * @return Objects\Diff\Diff
      */
-    public function getDiff(string $commit1 = null, string $commit2 = null, string $path = null)
+    public function getDiff(string $commit1 = null, string $commit2 = null, string $path = null): \GitElephant\Objects\Diff\Diff
     {
         return Diff::create($this, $commit1, $commit2, $path);
     }
@@ -971,7 +969,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function cloneFrom(string $url, string $to = null, string $repoReference = null, int $depth = null, bool $recursive = false)
+    public function cloneFrom(string $url, string $to = null, string $repoReference = null, int $depth = null, bool $recursive = false): self
     {
         $command = (Command\CloneCommand::getInstance($this))->cloneUrl($url, $to, $repoReference, $depth, $recursive);
         $this->caller->execute($command);
@@ -988,7 +986,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function addRemote(string $name, string $url)
+    public function addRemote(string $name, string $url): self
     {
         $this->caller->execute(RemoteCommand::getInstance($this)->add($name, $url));
 
@@ -1001,7 +999,7 @@ class Repository
      *
      * @return \GitElephant\Objects\Remote
      */
-    public function getRemote(string $name, bool $queryRemotes = true)
+    public function getRemote(string $name, bool $queryRemotes = true): \GitElephant\Objects\Remote
     {
         return Remote::pick($this, $name, $queryRemotes);
     }
@@ -1017,7 +1015,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return array
      */
-    public function getRemotes(bool $queryRemotes = true)
+    public function getRemotes(bool $queryRemotes = true): array
     {
         $remoteNames = $this->caller
             ->execute(RemoteCommand::getInstance($this)->show(null, $queryRemotes))
@@ -1043,10 +1041,10 @@ class Repository
      * @throws InvalidArgumentException
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      */
-    public function fetch($from = null, $ref = null, bool $tags = false)
+    public function fetch($from = null, $ref = null, bool $tags = false): void
     {
         $options = [];
-        if ($tags === true) {
+        if ($tags) {
             $options = ['--tags'];
         }
         $this->caller->execute(FetchCommand::getInstance($this)->fetch($from, $ref, $options));
@@ -1064,7 +1062,7 @@ class Repository
      * @throws InvalidArgumentException
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      */
-    public function pull($from = null, $ref = null, bool $rebase = true)
+    public function pull($from = null, $ref = null, bool $rebase = true): void
     {
         $this->caller->execute(PullCommand::getInstance($this)->pull($from, $ref, $rebase));
     }
@@ -1081,7 +1079,7 @@ class Repository
      * @throws InvalidArgumentException
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      */
-    public function push($to = null, $ref = null, string $args = null)
+    public function push($to = null, $ref = null, string $args = null): void
     {
         $this->caller->execute(PushCommand::getInstance($this)->push($to, $ref, $args));
     }
@@ -1091,13 +1089,12 @@ class Repository
      *
      * @return string
      */
-    public function getHumanishName()
+    public function getHumanishName(): string
     {
         $name = substr($this->getPath(), strrpos($this->getPath(), '/') + 1);
         $name = str_replace('.git', '.', $name);
-        $name = str_replace('.bundle', '.', $name);
 
-        return $name;
+        return str_replace('.bundle', '.', $name);
     }
 
     /**
@@ -1112,7 +1109,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return array
      */
-    public function outputContent(NodeObject $obj, $treeish)
+    public function outputContent(NodeObject $obj, $treeish): array
     {
         $command = CatFileCommand::getInstance($this)->content($obj, $treeish);
 
@@ -1131,7 +1128,7 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return string
      */
-    public function outputRawContent(NodeObject $obj, $treeish)
+    public function outputRawContent(NodeObject $obj, $treeish): string
     {
         $command = CatFileCommand::getInstance($this)->content($obj, $treeish);
 
@@ -1143,7 +1140,7 @@ class Repository
      *
      * @return string
      */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }
@@ -1153,7 +1150,7 @@ class Repository
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -1163,7 +1160,7 @@ class Repository
      *
      * @param string $name the repository name
      */
-    public function setName(string $name)
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
@@ -1173,7 +1170,7 @@ class Repository
      *
      * @param \GitElephant\Command\Caller\Caller $caller the caller variable
      */
-    public function setCaller(Caller $caller)
+    public function setCaller(Caller $caller): void
     {
         $this->caller = $caller;
     }
@@ -1183,7 +1180,7 @@ class Repository
      *
      * @return \GitElephant\Command\Caller\Caller
      */
-    public function getCaller()
+    public function getCaller(): \GitElephant\Command\Caller\Caller
     {
         return $this->caller;
     }
@@ -1193,7 +1190,7 @@ class Repository
      *
      * @return array Global config list
      */
-    public function getGlobalConfigs()
+    public function getGlobalConfigs(): array
     {
         return $this->globalConfigs;
     }
@@ -1204,7 +1201,7 @@ class Repository
      * @param string $name  The config name
      * @param mixed  $value The config value
      */
-    public function addGlobalConfig(string $name, $value)
+    public function addGlobalConfig(string $name, $value): void
     {
         $this->globalConfigs[$name] = $value;
     }
@@ -1214,7 +1211,7 @@ class Repository
      *
      * @param  string $name The config name
      */
-    public function removeGlobalConfig(string $name)
+    public function removeGlobalConfig(string $name): void
     {
         if (isset($this->globalConfigs[$name])) {
             unset($this->globalConfigs[$name]);
@@ -1226,7 +1223,7 @@ class Repository
      *
      * @return array Global options list
      */
-    public function getGlobalOptions()
+    public function getGlobalOptions(): array
     {
         return $this->globalOptions;
     }
@@ -1237,7 +1234,7 @@ class Repository
      * @param string $name  The option name
      * @param mixed  $value The option value
      */
-    public function addGlobalOption(string $name, $value)
+    public function addGlobalOption(string $name, $value): void
     {
         $this->globalOptions[$name] = $value;
     }
@@ -1247,7 +1244,7 @@ class Repository
      *
      * @param  string $name The option name
      */
-    public function removeGlobalOption(string $name)
+    public function removeGlobalOption(string $name): void
     {
         if (isset($this->globalOptions[$name])) {
             unset($this->globalOptions[$name]);
@@ -1259,7 +1256,7 @@ class Repository
      *
      * @return array Global command arguments list
      */
-    public function getGlobalCommandArguments()
+    public function getGlobalCommandArguments(): array
     {
         return $this->globalCommandArguments;
     }
@@ -1269,7 +1266,7 @@ class Repository
      *
      * @param string $value The command argument
      */
-    public function addGlobalCommandArgument($value)
+    public function addGlobalCommandArgument($value): void
     {
         if (!in_array($value, $this->globalCommandArguments, true)) {
             $this->globalCommandArguments[] = $value;
@@ -1282,7 +1279,7 @@ class Repository
      *
      * @param  string $value The command argument
      */
-    public function removeGlobalCommandArgument($value)
+    public function removeGlobalCommandArgument($value): void
     {
         if (in_array($value, $this->globalCommandArguments, true)) {
             $index = array_search($value, $this->globalCommandArguments);
@@ -1297,7 +1294,7 @@ class Repository
      * @param boolean     $includeUntracked
      * @param boolean     $keepIndex
      */
-    public function stash(string $message = null, bool $includeUntracked = false, bool $keepIndex = false)
+    public function stash(string $message = null, bool $includeUntracked = false, bool $keepIndex = false): void
     {
         $stashCommand = StashCommand::getInstance($this);
         $command = $stashCommand->save($message, $includeUntracked, $keepIndex);
@@ -1311,7 +1308,7 @@ class Repository
      *
      * @return array
      */
-    public function stashList(array $options = null)
+    public function stashList(array $options = null): array
     {
         $stashCommand = StashCommand::getInstance($this);
         $command = $stashCommand->listStashes($options);
@@ -1327,7 +1324,7 @@ class Repository
      *
      * @return string
      */
-    public function stashShow(string $stash)
+    public function stashShow(string $stash): string
     {
         $stashCommand = StashCommand::getInstance($this);
         $command = $stashCommand->show($stash);
@@ -1341,7 +1338,7 @@ class Repository
      *
      * @param string $stash
      */
-    public function stashDrop(string $stash)
+    public function stashDrop(string $stash): void
     {
         $stashCommand = StashCommand::getInstance($this);
         $command = $stashCommand->drop($stash);
@@ -1354,7 +1351,7 @@ class Repository
      * @param string  $stash
      * @param boolean $index
      */
-    public function stashApply(string $stash, bool $index = false)
+    public function stashApply(string $stash, bool $index = false): void
     {
         $stashCommand = StashCommand::getInstance($this);
         $command = $stashCommand->apply($stash, $index);
@@ -1367,7 +1364,7 @@ class Repository
      * @param string  $stash
      * @param boolean $index
      */
-    public function stashPop(string $stash, bool $index = false)
+    public function stashPop(string $stash, bool $index = false): void
     {
         $stashCommand = StashCommand::getInstance($this);
         $command = $stashCommand->pop($stash, $index);
@@ -1380,7 +1377,7 @@ class Repository
      * @param string $branch
      * @param string $stash
      */
-    public function stashBranch(string $branch, string $stash)
+    public function stashBranch(string $branch, string $stash): void
     {
         $stashCommand = StashCommand::getInstance($this);
         $command = $stashCommand->branch($branch, $stash);
@@ -1389,9 +1386,8 @@ class Repository
 
     /**
      *  Save your local modifications to a new stash, and run git reset --hard to revert them.
-     *
      */
-    public function stashClear()
+    public function stashClear(): void
     {
         $stashCommand = StashCommand::getInstance($this);
         $command = $stashCommand->clear();
@@ -1404,7 +1400,7 @@ class Repository
      *
      * @return string
      */
-    public function stashCreate()
+    public function stashCreate(): string
     {
         $stashCommand = StashCommand::getInstance($this);
         $command = $stashCommand->clear();

--- a/src/GitElephant/Status/Status.php
+++ b/src/GitElephant/Status/Status.php
@@ -42,7 +42,7 @@ class Status
 
     /**
      * Private constructor in order to follow the singleton pattern
-     * 
+     *
      * @param Repository $repository
      *
      * @throws \RuntimeException
@@ -68,7 +68,7 @@ class Status
     /**
      * create from git command
      */
-    private function createFromCommand()
+    private function createFromCommand(): void
     {
         $command = MainCommand::getInstance($this->repository)->status(true);
         $lines = $this->repository->getCaller()->execute($command)->getOutputLines(true);
@@ -80,7 +80,7 @@ class Status
      *
      * @return Sequence
      */
-    public function all()
+    public function all(): \PhpCollection\Sequence
     {
         return new Sequence($this->files);
     }
@@ -90,7 +90,7 @@ class Status
      *
      * @return Sequence
      */
-    public function untracked()
+    public function untracked(): \PhpCollection\Sequence
     {
         return $this->filterByType(StatusFile::UNTRACKED);
     }
@@ -100,7 +100,7 @@ class Status
      *
      * @return Sequence
      */
-    public function modified()
+    public function modified(): \PhpCollection\Sequence
     {
         return $this->filterByType(StatusFile::MODIFIED);
     }
@@ -110,7 +110,7 @@ class Status
      *
      * @return Sequence
      */
-    public function added()
+    public function added(): \PhpCollection\Sequence
     {
         return $this->filterByType(StatusFile::ADDED);
     }
@@ -120,7 +120,7 @@ class Status
      *
      * @return Sequence
      */
-    public function deleted()
+    public function deleted(): \PhpCollection\Sequence
     {
         return $this->filterByType(StatusFile::DELETED);
     }
@@ -130,7 +130,7 @@ class Status
      *
      * @return Sequence
      */
-    public function renamed()
+    public function renamed(): \PhpCollection\Sequence
     {
         return $this->filterByType(StatusFile::RENAMED);
     }
@@ -140,7 +140,7 @@ class Status
      *
      * @return Sequence
      */
-    public function copied()
+    public function copied(): \PhpCollection\Sequence
     {
         return $this->filterByType(StatusFile::COPIED);
     }
@@ -152,7 +152,7 @@ class Status
      *
      * @param array $lines
      */
-    private function parseOutputLines(array $lines)
+    private function parseOutputLines(array $lines): void
     {
         foreach ($lines as $line) {
             preg_match('/([MADRCU\? ])?([MADRCU\? ])?\ "?(\S+)"? ?( -> )?(\S+)?/', $line, $matches);
@@ -183,7 +183,7 @@ class Status
      *
      * @return Sequence
      */
-    protected function filterByType(string $type)
+    protected function filterByType(string $type): \PhpCollection\Sequence
     {
         if (!$this->files) {
             return new Sequence();

--- a/src/GitElephant/Status/StatusFile.php
+++ b/src/GitElephant/Status/StatusFile.php
@@ -116,7 +116,7 @@ class StatusFile
      *
      * @return string
      */
-    public function getIndexStatus(): string
+    public function getIndexStatus(): ?string
     {
         return $this->x;
     }
@@ -124,9 +124,9 @@ class StatusFile
     /**
      * Get the status of the working tree
      *
-     * @return string
+     * @return string|null
      */
-    public function getWorkingTreeStatus(): string
+    public function getWorkingTreeStatus(): ?string
     {
         return $this->y;
     }

--- a/src/GitElephant/Status/StatusFile.php
+++ b/src/GitElephant/Status/StatusFile.php
@@ -88,7 +88,7 @@ class StatusFile
      *
      * @return StatusFile
      */
-    public static function create(string $x, string $y, string $name, string $renamed = null)
+    public static function create(string $x, string $y, string $name, string $renamed = null): \GitElephant\Status\StatusFile
     {
         return new self($x, $y, $name, $renamed);
     }
@@ -96,7 +96,7 @@ class StatusFile
     /**
      * @return bool
      */
-    public function isRenamed()
+    public function isRenamed(): bool
     {
         return $this->renamed !== null;
     }
@@ -106,7 +106,7 @@ class StatusFile
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -116,7 +116,7 @@ class StatusFile
      *
      * @return string
      */
-    public function getIndexStatus()
+    public function getIndexStatus(): string
     {
         return $this->x;
     }
@@ -126,7 +126,7 @@ class StatusFile
      *
      * @return string
      */
-    public function getWorkingTreeStatus()
+    public function getWorkingTreeStatus(): string
     {
         return $this->y;
     }
@@ -136,7 +136,7 @@ class StatusFile
      *
      * @return string
      */
-    public function calculateDescription()
+    public function calculateDescription(): void
     {
         $status = $this->x . $this->y;
         $matching = [
@@ -174,7 +174,7 @@ class StatusFile
      *
      * @param string $description the description variable
      */
-    public function setDescription(string $description)
+    public function setDescription(string $description): void
     {
         $this->description = $description;
     }
@@ -184,7 +184,7 @@ class StatusFile
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         if ($this->description === null) {
             $this->calculateDescription();
@@ -197,7 +197,7 @@ class StatusFile
      *
      * @param string $type the type variable
      */
-    public function setType(string $type)
+    public function setType(string $type): void
     {
         $this->type = $type;
     }
@@ -207,7 +207,7 @@ class StatusFile
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }

--- a/src/GitElephant/Status/StatusIndex.php
+++ b/src/GitElephant/Status/StatusIndex.php
@@ -31,7 +31,7 @@ class StatusIndex extends Status
     /**
      * @return Sequence
      */
-    public function untracked()
+    public function untracked(): \PhpCollection\Sequence
     {
         return new Sequence();
     }
@@ -41,7 +41,7 @@ class StatusIndex extends Status
      *
      * @return Sequence
      */
-    public function all()
+    public function all(): \PhpCollection\Sequence
     {
         return new Sequence(
             array_filter(
@@ -60,7 +60,7 @@ class StatusIndex extends Status
      *
      * @return Sequence
      */
-    protected function filterByType(string $type)
+    protected function filterByType(string $type): \PhpCollection\Sequence
     {
         if (!$this->files) {
             return new Sequence();

--- a/src/GitElephant/Status/StatusWorkingTree.php
+++ b/src/GitElephant/Status/StatusWorkingTree.php
@@ -33,7 +33,7 @@ class StatusWorkingTree extends Status
      *
      * @return Sequence
      */
-    public function all()
+    public function all(): \PhpCollection\Sequence
     {
         return new Sequence(
             array_filter(
@@ -52,7 +52,7 @@ class StatusWorkingTree extends Status
      *
      * @return Sequence
      */
-    protected function filterByType(string $type)
+    protected function filterByType(string $type): \PhpCollection\Sequence
     {
         if (!$this->files) {
             return new Sequence();

--- a/tests/GitElephant/Command/BaseCommandTest.php
+++ b/tests/GitElephant/Command/BaseCommandTest.php
@@ -23,7 +23,7 @@ class BaseCommandTest extends TestCase
      *
      * @covers GitElephant\Command\BaseCommand::__construct
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $bc1 = new BaseCommand();
         $this->assertInstanceOf("\\GitElephant\\Command\\BaseCommand", $bc1);
@@ -65,13 +65,13 @@ class BaseCommandTest extends TestCase
      *
      * @covers GitElephant\Command\BaseCommand::getInstance
      */
-    public function testGetInstance()
+    public function testGetInstance(): void
     {
         $bc = BaseCommand::getInstance();
         $this->assertInstanceOf("\\GitElephant\\Command\\BaseCommand", $bc);
     }
 
-    public function testAddGlobalConfigs()
+    public function testAddGlobalConfigs(): void
     {
         $configs = ['one' => 1, 'two' => 2, 'three' => 3];
         $bc = BaseCommand::getInstance();
@@ -87,7 +87,7 @@ class BaseCommandTest extends TestCase
         $this->assertSame($configs, $ref_bc_cfg_prop->getValue($bc));
     }
 
-    public function testAddGlobalOptions()
+    public function testAddGlobalOptions(): void
     {
         $options = ['one' => 1, 'two' => 2, 'three' => 3];
         $bc = BaseCommand::getInstance();
@@ -103,7 +103,7 @@ class BaseCommandTest extends TestCase
         $this->assertSame($options, $ref_bc_opt_prop->getValue($bc));
     }
 
-    public function testAddGlobalCommandArguments()
+    public function testAddGlobalCommandArguments(): void
     {
         $arguments = ['one', 'two', 'three'];
         $bc = BaseCommand::getInstance();
@@ -121,7 +121,7 @@ class BaseCommandTest extends TestCase
         $this->assertSame($arguments, $ref_bc_arg_prop->getValue($bc));
     }
 
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         $name = 'command';
         $bc = BaseCommand::getInstance();
@@ -142,14 +142,14 @@ class BaseCommandTest extends TestCase
     /**
      * testGetCommandException
      */
-    public function testGetCommandException()
+    public function testGetCommandException(): void
     {
         $bc = BaseCommand::getInstance();
         $this->expectException('RuntimeException');
         $this->fail($bc->getCommand());
     }
 
-    public function testGetCLICommandArguments()
+    public function testGetCLICommandArguments(): void
     {
         $args = ['--first', '--second', '--third'];
         $bc = BaseCommand::getInstance();
@@ -170,7 +170,7 @@ class BaseCommandTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testGetCLICommandName()
+    public function testGetCLICommandName(): void
     {
         $name = 'command';
         $bc = BaseCommand::getInstance();
@@ -188,7 +188,7 @@ class BaseCommandTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testGetCLIConfigs()
+    public function testGetCLIConfigs(): void
     {
         $globals = ['global.first' => 'a', 'global.second' => 'b'];
         $locals = ['local.first' => 'c', 'local.second' => 'd'];
@@ -216,7 +216,7 @@ class BaseCommandTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testGetCLIGlobalOptions()
+    public function testGetCLIGlobalOptions(): void
     {
         $options = ['first' => 'a', 'second' => 'b', 'third' => 'c'];
         $bc = BaseCommand::getInstance();
@@ -237,7 +237,7 @@ class BaseCommandTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testGetCLIPath()
+    public function testGetCLIPath(): void
     {
         $path = '/path/to/something';
         $bc = BaseCommand::getInstance();
@@ -255,7 +255,7 @@ class BaseCommandTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testGetCLISubjects()
+    public function testGetCLISubjects(): void
     {
         $subject1 = 'first';
         $subject2 = 'second';
@@ -278,7 +278,7 @@ class BaseCommandTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    public function testGetBinaryVersion()
+    public function testGetBinaryVersion(): void
     {
         $repo = $this->getRepository();
         $bc = BaseCommand::getInstance($repo);

--- a/tests/GitElephant/Command/BranchCommandTest.php
+++ b/tests/GitElephant/Command/BranchCommandTest.php
@@ -111,7 +111,7 @@ class BranchCommandTest extends TestCase
     public function testDelete(): void
     {
         $branch = new BranchCommand();
-        $this->assertEquals("branch '-d' 'test-branch'", $branch->delete('test-branch'),       'list branch command without force');
+        $this->assertEquals("branch '-d' 'test-branch'", $branch->delete('test-branch'), 'list branch command without force');
         $this->assertEquals("branch '-D' 'test-branch'", $branch->delete('test-branch', true), 'list branch command with force');
     }
 }

--- a/tests/GitElephant/Command/BranchCommandTest.php
+++ b/tests/GitElephant/Command/BranchCommandTest.php
@@ -41,7 +41,7 @@ class BranchCommandTest extends TestCase
      *
      * @covers GitElephant\Command\BranchCommand::create
      */
-    public function testCreate()
+    public function testCreate(): void
     {
         $branch = new BranchCommand();
         $this->assertEquals("branch 'test'", $branch->create('test'), 'create branch command');
@@ -58,7 +58,7 @@ class BranchCommandTest extends TestCase
      *
      * @covers GitElephant\Command\BranchCommand::listBranches
      */
-    public function testListBranches()
+    public function testListBranches(): void
     {
         $branch = new BranchCommand();
         $this->assertEquals($branch->listBranches(), "branch '-v' '--no-color' '--no-abbrev'");
@@ -71,7 +71,7 @@ class BranchCommandTest extends TestCase
      *
      * @covers GitElephant\Command\BranchCommand::lists
      */
-    public function testLists()
+    public function testLists(): void
     {
         $branch = new BranchCommand();
         $this->assertEquals($branch->lists(), "branch '-v' '--no-color' '--no-abbrev'");
@@ -82,7 +82,7 @@ class BranchCommandTest extends TestCase
     /**
      * testSingleInfo
      */
-    public function testSingleInfo()
+    public function testSingleInfo(): void
     {
         $bc = new BranchCommand();
         $this->assertEquals(
@@ -108,7 +108,7 @@ class BranchCommandTest extends TestCase
      *
      * @covers GitElephant\Command\BranchCommand::delete
      */
-    public function testDelete()
+    public function testDelete(): void
     {
         $branch = new BranchCommand();
         $this->assertEquals("branch '-d' 'test-branch'", $branch->delete('test-branch'),       'list branch command without force');

--- a/tests/GitElephant/Command/CallerTest.php
+++ b/tests/GitElephant/Command/CallerTest.php
@@ -35,7 +35,7 @@ class CallerTest extends TestCase
     /**
      * @covers GitElephant\Command\Caller\Caller::__construct
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $caller = new Caller(null, $this->getRepository()->getPath());
         $this->assertNotEmpty($caller->execute('--version'));
@@ -44,7 +44,7 @@ class CallerTest extends TestCase
     /**
      * testGetBinaryPath
      */
-    public function testGetBinaryPath()
+    public function testGetBinaryPath(): void
     {
         $c = new Caller(null, $this->repository->getPath());
         $this->assertEquals(exec('which git'), $c->getBinaryPath());
@@ -53,7 +53,7 @@ class CallerTest extends TestCase
     /**
      * testGetBinaryVersion
      */
-    public function testGetBinaryVersion()
+    public function testGetBinaryVersion(): void
     {
         $c = new Caller(null, $this->repository->getPath());
         $this->assertIsString($c->getBinaryVersion());
@@ -62,7 +62,7 @@ class CallerTest extends TestCase
     /**
      * testGetError
      */
-    public function testGetError()
+    public function testGetError(): void
     {
         $this->expectException(\RuntimeException::class);
         $binary = null;
@@ -74,7 +74,7 @@ class CallerTest extends TestCase
     /**
      * get output test
      */
-    public function testGetOutput()
+    public function testGetOutput(): void
     {
         $caller = new Caller(null, $this->getRepository()->getPath());
         $mainCommand = new MainCommand();
@@ -88,7 +88,7 @@ class CallerTest extends TestCase
     /**
      * testOutputLines
      */
-    public function testOutputLines()
+    public function testOutputLines(): void
     {
         $caller = new Caller(null, $this->getRepository()->getPath());
         $this->getRepository()->init();
@@ -105,7 +105,7 @@ class CallerTest extends TestCase
     /**
      * testGetRawOutput
      */
-    public function testGetRawOutput()
+    public function testGetRawOutput(): void
     {
         $this->getRepository()->init();
         $caller = new Caller(null, $this->getRepository()->getPath());
@@ -116,7 +116,7 @@ class CallerTest extends TestCase
     /**
      * testRepositoryValidation 
      */
-    public function testRepositoryValidation()
+    public function testRepositoryValidation(): void
     {
         $this->expectException(\GitElephant\Exception\InvalidRepositoryPathException::class);
         $caller = new Caller(null, 'someinvalidpath');

--- a/tests/GitElephant/Command/CallerTest.php
+++ b/tests/GitElephant/Command/CallerTest.php
@@ -114,7 +114,7 @@ class CallerTest extends TestCase
     }
 
     /**
-     * testRepositoryValidation 
+     * testRepositoryValidation
      */
     public function testRepositoryValidation(): void
     {

--- a/tests/GitElephant/Command/CatFileCommandTest.php
+++ b/tests/GitElephant/Command/CatFileCommandTest.php
@@ -41,7 +41,7 @@ class CatFileCommandTest extends TestCase
     /**
      * CatFileCommand::content()
      */
-    public function testContent()
+    public function testContent(): void
     {
         $cfc = new CatFileCommand();
         $master = $this->getRepository()->getBranch('master');

--- a/tests/GitElephant/Command/CloneCommandTest.php
+++ b/tests/GitElephant/Command/CloneCommandTest.php
@@ -41,7 +41,7 @@ class CloneCommandTest extends TestCase
     /**
      * set up
      */
-    public function testCloneUrl()
+    public function testCloneUrl(): void
     {
         $cc = CloneCommand::getInstance($this->getRepository());
         $this->assertEquals(

--- a/tests/GitElephant/Command/DiffCommandTest.php
+++ b/tests/GitElephant/Command/DiffCommandTest.php
@@ -25,7 +25,7 @@ use \GitElephant\TestCase;
 class DiffCommandTest extends TestCase
 {
     /**
-     * @var \GitElephant\Command\DiffCommand;
+     * @var \GitElephant\Command\DiffCommand ;
      */
     private $diffCommand;
 
@@ -44,7 +44,7 @@ class DiffCommandTest extends TestCase
     /**
      * diff test
      */
-    public function testDiff()
+    public function testDiff(): void
     {
         $commit = $this->getRepository()->init()->getCommit();
         $this->assertEquals(

--- a/tests/GitElephant/Command/DiffTreeCommandTest.php
+++ b/tests/GitElephant/Command/DiffTreeCommandTest.php
@@ -39,7 +39,7 @@ class DiffTreeCommandTest extends TestCase
     /**
      * set up
      */
-    public function testRootDiff()
+    public function testRootDiff(): void
     {
         $dtc = DiffTreeCommand::getInstance();
         $commit = $this->getRepository()->getCommit();

--- a/tests/GitElephant/Command/FetchCommandTest.php
+++ b/tests/GitElephant/Command/FetchCommandTest.php
@@ -46,7 +46,7 @@ class FetchCommandTest extends TestCase
     /**
      * fetch test
      */
-    public function testFetch()
+    public function testFetch(): void
     {
         $fc = FetchCommand::getInstance();
         $this->assertEquals("fetch", $fc->fetch());

--- a/tests/GitElephant/Command/LogCommandTest.php
+++ b/tests/GitElephant/Command/LogCommandTest.php
@@ -40,7 +40,7 @@ class LogCommandTest extends TestCase
     /**
      * testShowObjectLog
      */
-    public function testShowObjectLog()
+    public function testShowObjectLog(): void
     {
         $branch = $this->getRepository()->getBranch('master');
         $obj = $this->getRepository()->getTree('HEAD', 'test-folder/test-file')->getBlob();

--- a/tests/GitElephant/Command/LsTreeCommandTest.php
+++ b/tests/GitElephant/Command/LsTreeCommandTest.php
@@ -11,7 +11,7 @@
  * Just for fun...
  */
 
-namespace GitElephant;
+namespace GitElephant\Command;
 
 use \GitElephant\Command\LsTreeCommand;
 use \GitElephant\TestCase;
@@ -26,7 +26,7 @@ use \GitElephant\TestCase;
 class LsTreeCommandTest extends TestCase
 {
     /**
-     * @var \GitElephant\Command\LsTreeCommand;
+     * @var \GitElephant\Command\LsTreeCommand ;
      */
     private $lsTreeCommand;
 
@@ -43,7 +43,7 @@ class LsTreeCommandTest extends TestCase
      *
      * @covers \GitElephant\Command\LsTreeCommand::tree
      */
-    public function testFullTree()
+    public function testFullTree(): void
     {
         $this->assertEquals("ls-tree '-r' '-t' '-l' 'HEAD'", $this->lsTreeCommand->fullTree(), 'ls-tree command test');
     }
@@ -53,7 +53,7 @@ class LsTreeCommandTest extends TestCase
      *
      * @covers \GitElephant\Command\LsTreeCommand::tree
      */
-    public function testTree()
+    public function testTree(): void
     {
         $this->assertEquals("ls-tree '-l' 'HEAD'", $this->lsTreeCommand->tree(), 'ls-tree command test');
     }
@@ -63,7 +63,7 @@ class LsTreeCommandTest extends TestCase
      *
      * @covers \GitElephant\Command\LsTreeCommand::listAll
      */
-    public function testListAll()
+    public function testListAll(): void
     {
         $this->assertEquals("ls-tree 'HEAD'", $this->lsTreeCommand->listAll(), 'ls-tree command test');
     }

--- a/tests/GitElephant/Command/MainCommandTest.php
+++ b/tests/GitElephant/Command/MainCommandTest.php
@@ -12,7 +12,7 @@
  * Just for fun...
  */
 
-namespace GitElephant;
+namespace GitElephant\Command;
 
 use \GitElephant\TestCase;
 use \GitElephant\Command\MainCommand;
@@ -28,7 +28,7 @@ use \GitElephant\Command\MainCommand;
 class MainCommandTest extends TestCase
 {
     /**
-     * @var \GitElephant\Command\MainCommand;
+     * @var \GitElephant\Command\MainCommand ;
      */
     private $mainCommand;
 
@@ -43,7 +43,7 @@ class MainCommandTest extends TestCase
     /**
      * init test
      */
-    public function testInit()
+    public function testInit(): void
     {
         $this->assertEquals(MainCommand::GIT_INIT, $this->mainCommand->init());
         $this->assertEquals(MainCommand::GIT_INIT . " '--bare'", $this->mainCommand->init(true));
@@ -52,7 +52,7 @@ class MainCommandTest extends TestCase
     /**
      * status test
      */
-    public function testStatus()
+    public function testStatus(): void
     {
         $this->assertEquals("'-c' 'color.status'='false' " . MainCommand::GIT_STATUS, $this->mainCommand->status());
     }
@@ -60,7 +60,7 @@ class MainCommandTest extends TestCase
     /**
      * add test
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         $this->assertEquals(MainCommand::GIT_ADD . " '--all' '.'", $this->mainCommand->add());
         $this->assertEquals(MainCommand::GIT_ADD . " '--all' 'foo'", $this->mainCommand->add('foo'));
@@ -69,7 +69,7 @@ class MainCommandTest extends TestCase
     /**
      * unstage test
      */
-    public function testUnstage()
+    public function testUnstage(): void
     {
         $this->assertEquals(MainCommand::GIT_RESET . " 'HEAD' -- 'foo'", $this->mainCommand->unstage('foo'));
     }
@@ -77,7 +77,7 @@ class MainCommandTest extends TestCase
     /**
      * commit test
      */
-    public function testCommit()
+    public function testCommit(): void
     {
         $this->assertEquals(MainCommand::GIT_COMMIT . " '-m' 'foo'", $this->mainCommand->commit('foo'));
         $this->assertEquals(MainCommand::GIT_COMMIT . " '-a' '-m' 'foo'", $this->mainCommand->commit('foo', true));
@@ -98,7 +98,7 @@ class MainCommandTest extends TestCase
     /**
      * checkout test
      */
-    public function testCheckout()
+    public function testCheckout(): void
     {
         $this->assertEquals(MainCommand::GIT_CHECKOUT . " '-q' 'master'", $this->mainCommand->checkout('master'));
     }

--- a/tests/GitElephant/Command/MergeCommandTest.php
+++ b/tests/GitElephant/Command/MergeCommandTest.php
@@ -45,7 +45,7 @@ class MergeCommandTest extends TestCase
     /**
      * MergeCommand should throw an exception when both --ff-only and --no-ff flags were set.
      */
-    public function test_exception_when_calling_merge_with_conflicting_ff_arguments(): void
+    public function testExceptionWhenCallingMergeWithConflictingFfArguments(): void
     {
         $branch = $this->getRepository()->getBranch('test');
         $this->expectException(\Symfony\Component\Process\Exception\InvalidArgumentException::class);

--- a/tests/GitElephant/Command/MergeCommandTest.php
+++ b/tests/GitElephant/Command/MergeCommandTest.php
@@ -32,7 +32,7 @@ class MergeCommandTest extends TestCase
     /**
      * testMerge
      */
-    public function testMerge()
+    public function testMerge(): void
     {
         $mc     = MergeCommand::getInstance();
         $branch = $this->getRepository()->getBranch('test');
@@ -45,7 +45,7 @@ class MergeCommandTest extends TestCase
     /**
      * MergeCommand should throw an exception when both --ff-only and --no-ff flags were set.
      */
-    public function test_exception_when_calling_merge_with_conflicting_ff_arguments()
+    public function test_exception_when_calling_merge_with_conflicting_ff_arguments(): void
     {
         $branch = $this->getRepository()->getBranch('test');
         $this->expectException(\Symfony\Component\Process\Exception\InvalidArgumentException::class);

--- a/tests/GitElephant/Command/MvCommandTest.php
+++ b/tests/GitElephant/Command/MvCommandTest.php
@@ -32,7 +32,7 @@ class MvCommandTest extends TestCase
     /**
      * testRename
      */
-    public function testRename()
+    public function testRename(): void
     {
         $mc = MvCommand::getInstance();
         $this->assertEquals("mv '-k' 'a' 'b'", $mc->rename('a', 'b'));

--- a/tests/GitElephant/Command/PullCommandTest.php
+++ b/tests/GitElephant/Command/PullCommandTest.php
@@ -47,7 +47,7 @@ class PullCommandTest extends TestCase
     /**
      * clone url
      */
-    public function testPull()
+    public function testPull(): void
     {
         $pc = PullCommand::getInstance();
         $this->assertEquals("pull", $pc->pull());

--- a/tests/GitElephant/Command/PushCommandTest.php
+++ b/tests/GitElephant/Command/PushCommandTest.php
@@ -47,7 +47,7 @@ class PushCommandTest extends TestCase
     /**
      * clone url
      */
-    public function testPush()
+    public function testPush(): void
     {
         $pc = PushCommand::getInstance();
         $this->assertEquals("push 'origin' 'master'", $pc->push());

--- a/tests/GitElephant/Command/RemoteCommandTest.php
+++ b/tests/GitElephant/Command/RemoteCommandTest.php
@@ -43,7 +43,7 @@ class RemoteCommandTest extends TestCase
     /**
      * Validate generated command when no arguements and no repository are used
      */
-    public function testRemoteNoArgs()
+    public function testRemoteNoArgs(): void
     {
         $actual = RemoteCommand::getInstance()->remote();
         $expected = "remote";
@@ -53,7 +53,7 @@ class RemoteCommandTest extends TestCase
     /**
      * validate git-remote show [name]
      */
-    public function testShow()
+    public function testShow(): void
     {
         $remotename = 'foobar';
         $actual = RemoteCommand::getInstance()->show($remotename);
@@ -68,7 +68,7 @@ class RemoteCommandTest extends TestCase
     /**
      * validate git-remote --verbose
      */
-    public function testVerbose()
+    public function testVerbose(): void
     {
         $actual = RemoteCommand::getInstance()->verbose();
         $expected = "remote '--verbose'";
@@ -78,7 +78,7 @@ class RemoteCommandTest extends TestCase
     /**
      * validate git-remote add [options] <name> <url>
      */
-    public function testAdd()
+    public function testAdd(): void
     {
         $name = 'foobar';
         $url = 'git@foobar.com:/Foo/Bar.git';

--- a/tests/GitElephant/Command/ResetCommandTest.php
+++ b/tests/GitElephant/Command/ResetCommandTest.php
@@ -25,7 +25,7 @@ class ResetCommandTest extends TestCase
         $this->getRepository()->createBranch('test', 'master');
     }
 
-    public function testResetHard()
+    public function testResetHard(): void
     {
         $rstc = ResetCommand::getInstance();
         $this->assertEquals("reset '--hard' 'dbeac'", $rstc->reset('dbeac', array(ResetCommand::OPTION_HARD)));

--- a/tests/GitElephant/Command/RevParseCommandTest.php
+++ b/tests/GitElephant/Command/RevParseCommandTest.php
@@ -23,7 +23,7 @@ use \GitElephant\TestCase;
  */
 class RevParseCommandTest extends TestCase
 {
-    public function testRevParse()
+    public function testRevParse(): void
     {
         $c = RevParseCommand::getInstance();
         $this->assertEquals("rev-parse 'master'", $c->revParse('master'));
@@ -34,7 +34,7 @@ class RevParseCommandTest extends TestCase
         )));
     }
 
-    public function testRevParseIsBare()
+    public function testRevParseIsBare(): void
     {
         $this->initRepository(null, 0);
         $repo = $this->getRepository(0);

--- a/tests/GitElephant/Command/StashCommandTest.php
+++ b/tests/GitElephant/Command/StashCommandTest.php
@@ -20,7 +20,7 @@ class StashCommandTest extends TestCase
     /**
      * testSave
      */
-    public function testSave()
+    public function testSave(): void
     {
         $command = StashCommand::getInstance();
         $this->assertEquals("stash save 'Test'", $command->save('Test'));
@@ -30,7 +30,7 @@ class StashCommandTest extends TestCase
     /**
      * testList
      */
-    public function testList()
+    public function testList(): void
     {
         $command = StashCommand::getInstance();
         $this->assertEquals("stash list", $command->listStashes());
@@ -40,7 +40,7 @@ class StashCommandTest extends TestCase
     /**
      * testShow
      */
-    public function testShow()
+    public function testShow(): void
     {
         $command = StashCommand::getInstance();
         $this->assertEquals("stash show 'stash@{0}'", $command->show(0));
@@ -49,7 +49,7 @@ class StashCommandTest extends TestCase
     /**
      * testDrop
      */
-    public function testDrop()
+    public function testDrop(): void
     {
         $command = StashCommand::getInstance();
         $this->assertEquals("stash drop 'stash@{0}'", $command->drop(0));
@@ -58,7 +58,7 @@ class StashCommandTest extends TestCase
     /**
      * testApply
      */
-    public function testApply()
+    public function testApply(): void
     {
         $command = StashCommand::getInstance();
         $this->assertEquals("stash apply 'stash@{0}'", $command->apply(0));
@@ -68,7 +68,7 @@ class StashCommandTest extends TestCase
     /**
      * testPop
      */
-    public function testPop()
+    public function testPop(): void
     {
         $command = StashCommand::getInstance();
         $this->assertEquals("stash pop 'stash@{0}'", $command->pop(0));
@@ -78,7 +78,7 @@ class StashCommandTest extends TestCase
     /**
      * testBranch
      */
-    public function testBranch()
+    public function testBranch(): void
     {
         $command = StashCommand::getInstance();
         $this->assertEquals("stash branch 'testbranch' 'stash@{0}'", $command->branch('testbranch', 0));
@@ -87,7 +87,7 @@ class StashCommandTest extends TestCase
     /**
      * testClear
      */
-    public function testClear()
+    public function testClear(): void
     {
         $command = StashCommand::getInstance();
         $this->assertEquals("stash clear", $command->clear());
@@ -96,7 +96,7 @@ class StashCommandTest extends TestCase
     /**
      * testCreate
      */
-    public function testCreate()
+    public function testCreate(): void
     {
         $command = StashCommand::getInstance();
         $this->assertEquals("stash create", $command->create());

--- a/tests/GitElephant/Command/SubCommandCommandTest.php
+++ b/tests/GitElephant/Command/SubCommandCommandTest.php
@@ -26,7 +26,7 @@ class SubCommandCommandTest extends TestCase
      * verify SubCommandCommands behavior, which is slightly
      * different that BaseCommand, for more sophisticated needs
      */
-    public function testGetCommand()
+    public function testGetCommand(): void
     {
         $cmdName = 'foo';
         $subOne = 'bar';

--- a/tests/GitElephant/Objects/AuthorTest.php
+++ b/tests/GitElephant/Objects/AuthorTest.php
@@ -27,7 +27,7 @@ class AuthorTest extends TestCase
     /**
      * testAuthor
      */
-    public function testAuthor()
+    public function testAuthor(): void
     {
         $author = new Author();
         $author->setEmail('foo@bar.com');

--- a/tests/GitElephant/Objects/BranchTest.php
+++ b/tests/GitElephant/Objects/BranchTest.php
@@ -3,10 +3,9 @@
  * User: matteo
  * Date: 05/01/13
  * Time: 0.18
- * 
+ *
  * Just for fun...
  */
-
 namespace GitElephant\Objects;
 
 use \GitElephant\TestCase;
@@ -20,7 +19,7 @@ class BranchTest extends TestCase
     /**
      * testGetMatches
      */
-    public function testGetMatches()
+    public function testGetMatches(): void
     {
         $matches = Branch::getMatches('* develop 45eac8c31adfbbf633824cee6ce8cc5040b33513 test message');
         $this->assertEquals('develop', $matches[1]);
@@ -46,7 +45,7 @@ class BranchTest extends TestCase
     /**
      * testGetMatchesErrors
      */
-    public function testGetMatchesShortShaError()
+    public function testGetMatchesShortShaError(): void
     {
         // short sha
         $this->expectException(\InvalidArgumentException::class);
@@ -55,9 +54,8 @@ class BranchTest extends TestCase
 
     /**
      * testGetMatchesErrors
-     *
      */
-    public function testGetMatchesNoSpaceError()
+    public function testGetMatchesNoSpaceError(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $matches = Branch::getMatches('* develop 45eac8c31adfbbf633824cee6ce8cc5040b33511test message');
@@ -66,7 +64,7 @@ class BranchTest extends TestCase
     /**
      * test constructor
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -87,7 +85,7 @@ class BranchTest extends TestCase
     /**
      * testBranchCreate
      */
-    public function testBranchCreate()
+    public function testBranchCreate(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -100,7 +98,7 @@ class BranchTest extends TestCase
     /**
      * __toString
      */
-    public function testToString()
+    public function testToString(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -112,7 +110,7 @@ class BranchTest extends TestCase
     /**
      * testCreate
      */
-    public function testCreate()
+    public function testCreate(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');

--- a/tests/GitElephant/Objects/Commit/MessageTest.php
+++ b/tests/GitElephant/Objects/Commit/MessageTest.php
@@ -46,7 +46,7 @@ HDOC;
     /**
      * @covers GitElephant\Objects\Commit\Message::getShortMessage
      */
-    public function testGetShortMessage()
+    public function testGetShortMessage(): void
     {
         $this->assertEquals($this->shortMsg, $this->msg->getShortMessage());
     }
@@ -54,7 +54,7 @@ HDOC;
     /**
      * @covers GitElephant\Objects\Commit\Message::getFullMessage
      */
-    public function testGetFullMessage()
+    public function testGetFullMessage(): void
     {
         $this->assertEquals($this->fullMsg, $this->msg->getFullMessage());
     }
@@ -62,7 +62,7 @@ HDOC;
     /**
      * @covers GitElephant\Objects\Commit\Message::toString
      */
-    public function testToString()
+    public function testToString(): void
     {
         $this->assertEquals($this->shortMsg, $this->msg->toString());
         $this->assertEquals($this->shortMsg, $this->msg->__toString());

--- a/tests/GitElephant/Objects/CommitTest.php
+++ b/tests/GitElephant/Objects/CommitTest.php
@@ -28,7 +28,7 @@ use \GitElephant\Command\CommandContainer;
 class CommitTest extends TestCase
 {
     /**
-     * @var \GitElephant\Objects\Commit;
+     * @var \GitElephant\Objects\Commit ;
      */
     private $commit;
 
@@ -45,7 +45,7 @@ class CommitTest extends TestCase
     /**
      * commit tests
      */
-    public function testCommit()
+    public function testCommit(): void
     {
         $showCommand = new ShowCommand();
         $this->commit = Commit::pick($this->getRepository());
@@ -71,7 +71,7 @@ class CommitTest extends TestCase
     /**
      * constructor regex test
      */
-    public function testCommitRegEx()
+    public function testCommitRegEx(): void
     {
         $outputLines = array(
             "commit c277373174aa442af12a8e59de1812f3472c15f5",
@@ -121,7 +121,7 @@ class CommitTest extends TestCase
     /**
      * testCommitDate
      */
-    public function testCommitDate()
+    public function testCommitDate(): void
     {
         $outputLines = array(
             "commit c277373174aa442af12a8e59de1812f3472c15f5",
@@ -153,7 +153,7 @@ class CommitTest extends TestCase
     /**
      * testCreateFromOutputLines
      */
-    public function testCreateFromOutputLines()
+    public function testCreateFromOutputLines(): void
     {
         $outputLines = array(
             "commit c277373174aa442af12a8e59de1812f3472c15f5",
@@ -182,7 +182,7 @@ class CommitTest extends TestCase
     /**
      * testCreate
      */
-    public function testCreate()
+    public function testCreate(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -194,7 +194,7 @@ class CommitTest extends TestCase
     /**
      * testGetDiff
      */
-    public function testGetDiff()
+    public function testGetDiff(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -213,7 +213,7 @@ class CommitTest extends TestCase
         $this->assertCount(2, $diff);
     }
 
-    public function testRevParse()
+    public function testRevParse(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -224,7 +224,7 @@ class CommitTest extends TestCase
         $this->assertEquals($commit->getSha(), $revParse[0]);
     }
 
-    public function testCommitWithoutTag()
+    public function testCommitWithoutTag(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -233,7 +233,7 @@ class CommitTest extends TestCase
         $this->assertFalse($commit->tagged());
     }
 
-    public function testCommitWithTag()
+    public function testCommitWithTag(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');

--- a/tests/GitElephant/Objects/Diff/DiffTest.php
+++ b/tests/GitElephant/Objects/Diff/DiffTest.php
@@ -40,7 +40,7 @@ class DiffTest extends TestCase
         $this->initRepository();
     }
 
-    public function testDiff()
+    public function testDiff(): void
     {
         $mainCommand = new MainCommand();
         $diffCommand = new DiffCommand();
@@ -70,7 +70,7 @@ class DiffTest extends TestCase
         }
     }
 
-    private function assertArrayInterfaces($obj)
+    private function assertArrayInterfaces($obj): void
     {
         $this->assertInstanceOf('\Iterator', $obj);
         $this->assertInstanceOf('\Countable', $obj);

--- a/tests/GitElephant/Objects/Diff/DiffTest.php
+++ b/tests/GitElephant/Objects/Diff/DiffTest.php
@@ -14,18 +14,18 @@
 namespace GitElephant\Objects\Diff;
 
 use \GitElephant\TestCase;
-use \GitElephant\Objects\Diff\Diff,
-    \GitElephant\Objects\Diff\DiffObject,
-    \GitElephant\Objects\Diff\DiffChunk,
-    \GitElephant\Objects\Diff\DiffChunkLine,
-    \GitElephant\Objects\Diff\DiffChunkLineAdded,
-    \GitElephant\Objects\Diff\DiffChunkLineDeleted,
-    \GitElephant\Objects\Diff\DiffChunkLineUnchanged,
-    \GitElephant\Objects\Commit;
+use \GitElephant\Objects\Diff\Diff;
+use \GitElephant\Objects\Diff\DiffObject;
+use \GitElephant\Objects\Diff\DiffChunk;
+use \GitElephant\Objects\Diff\DiffChunkLine;
+use \GitElephant\Objects\Diff\DiffChunkLineAdded;
+use \GitElephant\Objects\Diff\DiffChunkLineDeleted;
+use \GitElephant\Objects\Diff\DiffChunkLineUnchanged;
+use \GitElephant\Objects\Commit;
 
-use \GitElephant\Command\MainCommand,
-    \GitElephant\Command\DiffCommand,
-    \GitElephant\Command\ShowCommand;
+use \GitElephant\Command\MainCommand;
+use \GitElephant\Command\DiffCommand;
+use \GitElephant\Command\ShowCommand;
 
 /**
  * DiffTest

--- a/tests/GitElephant/Objects/LogRangeTest.php
+++ b/tests/GitElephant/Objects/LogRangeTest.php
@@ -61,7 +61,7 @@ class LogRangeTest extends TestCase
         $this->secondCommit = $log[8];
     }
 
-    public function testCreateFromCommand()
+    public function testCreateFromCommand(): void
     {
         $logRange = new LogRange($this->getRepository(0), $this->firstCommit, $this->lastCommit);
         $this->assertInstanceOf('\ArrayAccess', $logRange);
@@ -69,20 +69,20 @@ class LogRangeTest extends TestCase
         $this->assertInstanceOf('\Iterator', $logRange);
     }
 
-    public function testToArray()
+    public function testToArray(): void
     {
         $logRange = new LogRange($this->getRepository(0), $this->firstCommit, $this->lastCommit);
         $this->assertIsArray($logRange->toArray());
         $this->assertCount(9, $logRange->toArray());
     }
 
-    public function testIndex()
+    public function testIndex(): void
     {
         $logRange = new LogRange($this->getRepository(0), $this->firstCommit, $this->lastCommit);
         $this->assertEquals($this->lastCommit, $logRange->index(0));
     }
 
-    public function testArrayAccess()
+    public function testArrayAccess(): void
     {
         $logRange = new LogRange($this->getRepository(0), $this->firstCommit, $this->lastCommit);
         $this->assertEquals($this->lastCommit, $logRange->first());
@@ -102,7 +102,7 @@ class LogRangeTest extends TestCase
     /**
      * testExceptionOnSet
      */
-    public function testExceptionOnSet()
+    public function testExceptionOnSet(): void
     {
         $this->expectException(\RuntimeException::class);
         $logRange = new LogRange($this->getRepository(0), $this->firstCommit, $this->lastCommit);
@@ -112,7 +112,7 @@ class LogRangeTest extends TestCase
     /**
      * testExceptionOnUnSet
      */
-    public function testExceptionOnUnset()
+    public function testExceptionOnUnset(): void
     {
         $this->expectException(\RuntimeException::class);
         $logRange = new LogRange($this->getRepository(0), $this->firstCommit, $this->lastCommit);

--- a/tests/GitElephant/Objects/LogTest.php
+++ b/tests/GitElephant/Objects/LogTest.php
@@ -40,7 +40,7 @@ class LogTest extends TestCase
     /**
      * testLogCountable
      */
-    public function testLogCountable()
+    public function testLogCountable(): void
     {
         $log = $this->getRepository()->getLog();
         $this->assertEquals($log->count(), count($log));
@@ -49,7 +49,7 @@ class LogTest extends TestCase
     /**
      * parents created by log
      */
-    public function testParents()
+    public function testParents(): void
     {
         $log = $this->getRepository()->getLog();
         $lastCommit = $this->repository->getCommit();
@@ -74,7 +74,7 @@ class LogTest extends TestCase
     /**
      * testLogCountLimit
      */
-    public function testLogCountLimit()
+    public function testLogCountLimit(): void
     {
         $log = $this->getRepository()->getLog();
         $this->assertEquals(10, $log->count());
@@ -107,7 +107,7 @@ class LogTest extends TestCase
     /**
      * testLogOffset
      */
-    public function testLogOffset()
+    public function testLogOffset(): void
     {
         $log = $this->getRepository()->getLog('HEAD', null, 15, 0);
         $this->assertEquals(10, $log->count());
@@ -125,7 +125,7 @@ class LogTest extends TestCase
     /**
      * testLogIndex
      */
-    public function testLogIndex()
+    public function testLogIndex(): void
     {
         $log = $this->getRepository()->getLog();
 
@@ -138,7 +138,7 @@ class LogTest extends TestCase
     /**
      * testLogToArray
      */
-    public function testLogToArray()
+    public function testLogToArray(): void
     {
         $log = $this->getRepository()->getLog();
 
@@ -150,7 +150,7 @@ class LogTest extends TestCase
     /**
      * testObjectLog
      */
-    public function testObjectLog()
+    public function testObjectLog(): void
     {
         $tree = $this->getRepository()->getTree();
         $file = $tree[0];
@@ -159,7 +159,7 @@ class LogTest extends TestCase
     /**
      * testLogCreatedFromOutputLines
      */
-    public function testLogCreatedFromOutputLines()
+    public function testLogCreatedFromOutputLines(): void
     {
         $tree = $this->getRepository()->getTree();
         $obj = $tree[count($tree) - 1];

--- a/tests/GitElephant/Objects/NodeObjectTest.php
+++ b/tests/GitElephant/Objects/NodeObjectTest.php
@@ -18,7 +18,7 @@ class NodeObjectTest extends TestCase
         $this->getRepository()->commit('first commit', true);
     }
 
-    public function testGetLastCommitFromTree()
+    public function testGetLastCommitFromTree(): void
     {
         $tree = $this->getRepository()->getTree('master');
         $testFile = $tree[0];
@@ -26,7 +26,7 @@ class NodeObjectTest extends TestCase
         $this->assertEquals('first commit', $testFile->getLastCommit()->getMessage());
     }
 
-    public function testGetLastCommitFromBranch()
+    public function testGetLastCommitFromBranch(): void
     {
         $this->getRepository()->createBranch('test');
         $this->getRepository()->checkout('test');
@@ -38,7 +38,7 @@ class NodeObjectTest extends TestCase
         $this->assertEquals('test branch commit', $testFile->getLastCommit()->getMessage()->getFullMessage());
     }
 
-    public function testGetLastCommitFromTag()
+    public function testGetLastCommitFromTag(): void
     {
         $this->getRepository()->createTag('test-tag');
         $tag = $this->getRepository()->getTag('test-tag');
@@ -52,7 +52,7 @@ class NodeObjectTest extends TestCase
         $this->assertEquals('tag 2 commit', $tag->getLastCommit()->getMessage());
     }
 
-    public function testRevParse()
+    public function testRevParse(): void
     {
         $master = $this->getRepository()->getBranch('master');
 
@@ -66,7 +66,7 @@ class NodeObjectTest extends TestCase
      * @covers GitElephant\Objects\NodeObject::getRepository
      * @covers GitElephant\Objects\NodeObject::setRepository
      */
-    public function testGetSetRepository()
+    public function testGetSetRepository(): void
     {
         $this->initRepository('object1', 1);
         $repo1 = $this->getRepository(1);

--- a/tests/GitElephant/Objects/RemoteTest.php
+++ b/tests/GitElephant/Objects/RemoteTest.php
@@ -59,7 +59,7 @@ class RemoteTest extends TestCase
      *
      * @return string
      */
-    public function sampleRemoteVerbose()
+    public function sampleRemoteVerbose(): string
     {
         $name = $this->sampleRemoteShowRemoteName();
         $fetch = $this->sampleRemoteShowFetchURL();
@@ -78,7 +78,7 @@ EOM;
      *
      * @return string
      */
-    public function sampleRemoteShowFetchURL()
+    public function sampleRemoteShowFetchURL(): string
     {
         return 'git@foobar.baz:blurg/burpfetch.git';
     }
@@ -88,7 +88,7 @@ EOM;
      *
      * @return string
      */
-    public function sampleRemoteShowPushURL()
+    public function sampleRemoteShowPushURL(): string
     {
         return 'git@foobar.baz:blurg/burppush.git';
     }
@@ -98,7 +98,7 @@ EOM;
      *
      * @return string
      */
-    public function sampleRemoteShowRemoteName()
+    public function sampleRemoteShowRemoteName(): string
     {
         return 'delphi';
     }
@@ -108,7 +108,7 @@ EOM;
      *
      * @return string
      */
-    public function sampleRemoteShowRemoteHEAD()
+    public function sampleRemoteShowRemoteHEAD(): void
     {
         'Apollo';
     }
@@ -118,7 +118,7 @@ EOM;
      *
      * @return string
      */
-    public function sampleRemoteShow()
+    public function sampleRemoteShow(): string
     {
         $name = $this->sampleRemoteShowRemoteName();
         $fetch = $this->sampleRemoteShowFetchURL();
@@ -159,7 +159,7 @@ EOM;
      *
      * @return array
      */
-    public function sampleRemoteShowAsArray()
+    public function sampleRemoteShowAsArray(): array
     {
         return [
             '11.30'                                => [
@@ -207,7 +207,7 @@ EOM;
     /**
      * test name getter
      */
-    public function testGetName()
+    public function testGetName(): void
     {
         $sample = $this->sampleRemoteShow();
         $output = explode("\n", $sample);
@@ -221,7 +221,7 @@ EOM;
     /**
      * test name setter
      */
-    public function testSetName()
+    public function testSetName(): void
     {
         $expected = 'foobar';
         $remote = new Remote($this->getRepository());
@@ -233,7 +233,7 @@ EOM;
     /**
      * test fetch URL getter
      */
-    public function testGetFetchURL()
+    public function testGetFetchURL(): void
     {
         $sample = $this->sampleRemoteShow();
         $output = explode("\n", $sample);
@@ -247,7 +247,7 @@ EOM;
     /**
      * test fetch URL setter
      */
-    public function testSetFetchURL()
+    public function testSetFetchURL(): void
     {
         $expected = 'foobar';
         $remote = new Remote($this->getRepository());
@@ -259,7 +259,7 @@ EOM;
     /**
      * test push URL getter
      */
-    public function testGetPushURL()
+    public function testGetPushURL(): void
     {
         $sample = $this->sampleRemoteShow();
         $output = explode("\n", $sample);
@@ -277,7 +277,7 @@ EOM;
     /**
      * test push URL setter
      */
-    public function testSetPushURL()
+    public function testSetPushURL(): void
     {
         $expected = 'foobar';
         $remote = new Remote($this->getRepository());
@@ -289,7 +289,7 @@ EOM;
     /**
      * test remote HEAD branch getter
      */
-    public function testGetRemoteHEAD()
+    public function testGetRemoteHEAD(): void
     {
         $sample = $this->sampleRemoteShow();
         $output = explode("\n", $sample);
@@ -307,7 +307,7 @@ EOM;
     /**
      * test remote HEAD branch setter
      */
-    public function testSetRemoteHEAD()
+    public function testSetRemoteHEAD(): void
     {
         $expected = 'foobar';
         $remote = new Remote($this->getRepository());
@@ -319,7 +319,7 @@ EOM;
     /**
      * test branch detail parsing
      */
-    public function testParseOutputLines()
+    public function testParseOutputLines(): void
     {
         $sample = $this->sampleRemoteShow();
         $output = explode("\n", $sample);
@@ -383,7 +383,7 @@ EOM;
      * is flawed.  However, it should do the trick so other tests
      * that depend on the double will have supporting test data/failures
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $obj = $this->getMockRemote();
         $this->assertInstanceOf(Remote::class, $obj);
@@ -392,7 +392,7 @@ EOM;
     /**
      * verify name is produced with cast to a string
      */
-    public function testToString()
+    public function testToString(): void
     {
         $obj = $this->getMockRemote();
         $this->assertEquals(
@@ -406,7 +406,7 @@ EOM;
      * verify that we always get an array, even if empty, when getting
      * data from the underlying implementation
      */
-    public function testGetVerboseOutputReturnArray()
+    public function testGetVerboseOutputReturnArray(): void
     {
         $remote = new Remote($this->getRepository());
         $actual = $remote->getVerboseOutput();
@@ -417,7 +417,7 @@ EOM;
      * verify that we always get an array, even if empty, when getting
      * data from the underlying implementation
      */
-    public function testGetShowOutputReturnArray()
+    public function testGetShowOutputReturnArray(): void
     {
         $remote = new Remote($this->getRepository());
         $actual = $remote->getShowOutput();

--- a/tests/GitElephant/Objects/TagTest.php
+++ b/tests/GitElephant/Objects/TagTest.php
@@ -17,7 +17,7 @@ class TagTest extends TestCase
     /**
      * testTag
      */
-    public function testTag()
+    public function testTag(): void
     {
         $this->getRepository()->init();
         $this->addFile('foo');
@@ -33,7 +33,7 @@ class TagTest extends TestCase
     /**
      * testTagFromStartPoint
      */
-    public function testTagFromStartPoint()
+    public function testTagFromStartPoint(): void
     {
         $this->getRepository()->init();
         $this->addFile('foo');
@@ -51,7 +51,7 @@ class TagTest extends TestCase
     /**
      * testNonExistentTag
      */
-    public function testNonExistentTag()
+    public function testNonExistentTag(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->getRepository()->init();
@@ -64,7 +64,7 @@ class TagTest extends TestCase
     /**
      * testCreate
      */
-    public function testCreate()
+    public function testCreate(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');

--- a/tests/GitElephant/Objects/TreeObjectTest.php
+++ b/tests/GitElephant/Objects/TreeObjectTest.php
@@ -15,7 +15,7 @@ class TreeObjectTest extends TestCase
         $this->getRepository()->commit('first commit', true);
     }
 
-    public function testInstance()
+    public function testInstance(): void
     {
         $tree = $this->getRepository()->getTree('master', 'test');
         $this->assertInstanceOf('GitElephant\Objects\TreeObject', $tree[0]);

--- a/tests/GitElephant/Objects/TreeTest.php
+++ b/tests/GitElephant/Objects/TreeTest.php
@@ -45,7 +45,7 @@ class TreeTest extends TestCase
     /**
      * testConstructor
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $tree = $this->repository->getTree('HEAD');
         $this->assertInstanceOf('Traversable', $tree);
@@ -64,7 +64,7 @@ class TreeTest extends TestCase
     /**
      * testWithPath
      */
-    public function testWithPath()
+    public function testWithPath(): void
     {
         /** @var Tree $tree */
         $tree = $this->repository->getTree('HEAD');
@@ -86,7 +86,7 @@ class TreeTest extends TestCase
     /**
      * testSubmodule
      */
-    public function testSubmodule()
+    public function testSubmodule(): void
     {
         $tempDir = realpath(sys_get_temp_dir()) . 'gitelephant_' . md5(uniqid(rand(), 1));
         // horrible hack because php is beautiful.
@@ -99,8 +99,8 @@ class TreeTest extends TestCase
         $repository->addSubmodule($this->repository->getPath());
         $repository->commit('test', true);
         $tree = $repository->getTree();
-        $this->assertContains('.gitmodules', $tree);
-        $this->assertContains($this->repository->getHumanishName(), $tree);
+        $this->assertContainsEquals('.gitmodules', $tree);
+        $this->assertContainsEquals($this->repository->getHumanishName(), $tree);
         $submodule = $tree[0];
         $this->assertEquals(NodeObject::TYPE_LINK, $submodule->getType());
     }
@@ -108,7 +108,7 @@ class TreeTest extends TestCase
     /**
      * testIsRoot
      */
-    public function testIsRoot()
+    public function testIsRoot(): void
     {
         $this->initRepository();
         $this->getRepository()->init();
@@ -122,7 +122,7 @@ class TreeTest extends TestCase
     /**
      * testGetObject
      */
-    public function testGetObject()
+    public function testGetObject(): void
     {
         $tree = $this->getRepository()->getTree();
         $this->assertNull($tree->getObject());

--- a/tests/GitElephant/RepositoryTest.php
+++ b/tests/GitElephant/RepositoryTest.php
@@ -513,7 +513,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::getLog
      */
-    public function testGetLog_for_a_branch(): void
+    public function testGetLogForBranch(): void
     {
         $this->getRepository()->init();
         $this->addFile('test file 0');

--- a/tests/GitElephant/RepositoryTest.php
+++ b/tests/GitElephant/RepositoryTest.php
@@ -40,7 +40,7 @@ class RepositoryTest extends TestCase
      * @covers \GitElephant\Repository::__construct
      * @covers \GitElephant\Repository::getPath
      */
-    public function testConstruct()
+    public function testConstruct(): void
     {
         $this->assertEquals($this->getRepository()->getPath(), $this->path);
 
@@ -54,7 +54,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::init
      */
-    public function testInit()
+    public function testInit(): void
     {
         $this->getRepository()->init();
         $match = false;
@@ -73,7 +73,7 @@ class RepositoryTest extends TestCase
     /**
      * testName
      */
-    public function testName()
+    public function testName(): void
     {
         $this->getRepository()->setName('test-repo');
         $this->assertEquals('test-repo', $this->getRepository()->getName());
@@ -82,7 +82,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::stage
      */
-    public function testStage()
+    public function testStage(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -99,7 +99,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::unstage
      */
-    public function testUnstage()
+    public function testUnstage(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -119,7 +119,7 @@ class RepositoryTest extends TestCase
      * @covers \GitElephant\Repository::commit
      * @covers \GitElephant\Repository::getStatusOutput
      */
-    public function testCommit()
+    public function testCommit(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -148,7 +148,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::getStatusOutput
      */
-    public function testGetStatus()
+    public function testGetStatus(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -157,13 +157,14 @@ class RepositoryTest extends TestCase
         $this->assertStringEndsWith('master', $output[0]);
         $this->addFile('file2');
         $output = $this->getRepository()->getStatusOutput();
-        $this->assertStringEndsWith('file2', $output[4]);
+        // $this->assertContains('file2', $output);
+        $this->assertStringEndsWith('file2', $output[3]);
     }
 
     /**
      * @covers \GitElephant\Repository::createBranch
      */
-    public function testCreateBranch()
+    public function testCreateBranch(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -175,7 +176,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::deleteBranch
      */
-    public function testDeleteBranch()
+    public function testDeleteBranch(): void
     {
         $this->getRepository()->init();
         $this->addFile('test-file');
@@ -195,7 +196,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::getBranches
      */
-    public function testGetBranches()
+    public function testGetBranches(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -237,7 +238,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::getMainBranch
      */
-    public function testGetMainBranch()
+    public function testGetMainBranch(): void
     {
         $this->getRepository()->init();
         $this->addFile('test-file');
@@ -248,7 +249,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::getBranch
      */
-    public function testGetBranch()
+    public function testGetBranch(): void
     {
         $this->getRepository()->init();
         $this->addFile('test-file');
@@ -260,7 +261,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::merge
      */
-    public function testMerge()
+    public function testMerge(): void
     {
         $this->getRepository()->init();
         $this->addFile('test-file');
@@ -309,7 +310,7 @@ class RepositoryTest extends TestCase
      * @covers \GitElephant\Repository::createTag
      * @covers \GitElephant\Repository::deleteTag
      */
-    public function testTags()
+    public function testTags(): void
     {
         $this->getRepository()->init();
         $this->addFile('test-file');
@@ -326,7 +327,7 @@ class RepositoryTest extends TestCase
     /**
      * test getLastTag
      */
-    public function testGetLastTag()
+    public function testGetLastTag(): void
     {
         $this->getRepository()->init();
         $this->addFile('test-file');
@@ -351,7 +352,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::getCommit
      */
-    public function testGetCommit()
+    public function testGetCommit(): void
     {
         $this->getRepository()->init();
         $this->addFile('test-file');
@@ -359,7 +360,7 @@ class RepositoryTest extends TestCase
         $this->assertInstanceOf('GitElephant\Objects\Commit', $this->getRepository()->getCommit());
     }
 
-    public function testGetBranchOrTag()
+    public function testGetBranchOrTag(): void
     {
         $this->getRepository()->init();
         $this->addFile('test-file');
@@ -374,7 +375,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::getObjectLog
      */
-    public function testGetObjectLog()
+    public function testGetObjectLog(): void
     {
         $repo = $this->getRepository();
         $repo->init();
@@ -415,7 +416,7 @@ class RepositoryTest extends TestCase
      *
      * @covers \GitElephant\Repository::getObjectLog
      */
-    public function testGetObjectLogFolders()
+    public function testGetObjectLogFolders(): void
     {
         $repo = $this->getRepository();
         $repo->init();
@@ -456,7 +457,7 @@ class RepositoryTest extends TestCase
      *
      * @covers \GitElephant\Repository::getObjectLog
      */
-    public function testGetObjectLogBranches()
+    public function testGetObjectLogBranches(): void
     {
         $repo = $this->getRepository();
         $repo->init();
@@ -496,7 +497,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::getLog
      */
-    public function testGetLog()
+    public function testGetLog(): void
     {
         $this->getRepository()->init();
 
@@ -513,7 +514,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::getLog
      */
-    public function testGetLog_for_a_branch()
+    public function testGetLog_for_a_branch(): void
     {
         $this->getRepository()->init();
         $this->addFile('test file 0');
@@ -533,7 +534,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::checkout
      */
-    public function testCheckout()
+    public function testCheckout(): void
     {
         $this->getRepository()->init();
         $this->addFile('test-file');
@@ -547,7 +548,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::checkout
      */
-    public function testCheckoutTag()
+    public function testCheckoutTag(): void
     {
         $this->getRepository()->init();
         $this->addFile('test-file');
@@ -569,7 +570,7 @@ class RepositoryTest extends TestCase
      * @covers \GitElephant\Repository::getTree
      * @covers \GitElephant\Objects\Tree
      */
-    public function testGetTree()
+    public function testGetTree(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -627,7 +628,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::getDiff
      */
-    public function testGetDiff()
+    public function testGetDiff(): void
     {
         $this->getRepository()->init();
         $this->addFile('test-file');
@@ -646,7 +647,7 @@ class RepositoryTest extends TestCase
     /**
      * testCloneFrom
      */
-    public function testCloneFrom()
+    public function testCloneFrom(): void
     {
         $this->initRepository(null, 0);
         $this->initRepository(null, 1);
@@ -664,7 +665,7 @@ class RepositoryTest extends TestCase
     /**
      * testOutputContent
      */
-    public function testOutputContent()
+    public function testOutputContent(): void
     {
         $this->initRepository();
         $this->getRepository()->init();
@@ -679,21 +680,20 @@ class RepositoryTest extends TestCase
     /**
      * testMove
      */
-    public function testMove()
+    public function testMove(): void
     {
         $this->getRepository()->init();
         $this->addFile('foo');
         $this->getRepository()->commit('commit 1', true);
         $this->getRepository()->move('foo', 'bar');
         $status = $this->getRepository()->getStatusOutput();
-
-        $this->assertRegExp('/(.*):    foo -> bar/', $status[4]);
+        $this->assertRegExp('/(.*):    foo -> bar/', $status[3]);
     }
 
     /**
      * testRemove
      */
-    public function testRemove()
+    public function testRemove(): void
     {
         $this->getRepository()->init();
         $this->addFile('foo');
@@ -701,13 +701,13 @@ class RepositoryTest extends TestCase
         $this->getRepository()->remove('foo');
         $status = $this->getRepository()->getStatusOutput();
 
-        $this->assertRegExp('/(.*):    foo/', $status[4]);
+        $this->assertRegExp('/(.*):    foo/', $status[3]);
     }
 
     /**
      * testCountCommits
      */
-    public function testCountCommits()
+    public function testCountCommits(): void
     {
         $this->getRepository()->init();
         $this->addFile('foo');
@@ -729,7 +729,7 @@ class RepositoryTest extends TestCase
     /**
      * testHumanishName
      */
-    public function testHumanishName()
+    public function testHumanishName(): void
     {
         $this->initRepository('test-dir');
         $this->assertEquals('test-dir', $this->getRepository()->getHumanishName());
@@ -737,9 +737,8 @@ class RepositoryTest extends TestCase
 
     /**
      * testCreateFromRemote
-     *
      */
-    public function testCreateFromRemote()
+    public function testCreateFromRemote(): void
     {
         $this->initRepository(null, 0);
         $remote = $this->getRepository(0);
@@ -765,7 +764,7 @@ class RepositoryTest extends TestCase
     /**
      * testAddRemote
      */
-    public function testRemote()
+    public function testRemote(): void
     {
         $this->initRepository(null, 0);
         $remote = $this->getRepository(0);
@@ -781,7 +780,7 @@ class RepositoryTest extends TestCase
     /**
      * testFetch, git branch -a should find the branch
      */
-    public function testFetch()
+    public function testFetch(): void
     {
         $this->initRepository(null, 0);
         $this->initRepository(null, 1);
@@ -806,7 +805,7 @@ class RepositoryTest extends TestCase
     /**
      * test pull
      */
-    public function testPull()
+    public function testPull(): void
     {
         $this->initRepository(null, 0);
         $this->initRepository(null, 1);
@@ -825,7 +824,7 @@ class RepositoryTest extends TestCase
     /**
      * test pull
      */
-    public function testPush()
+    public function testPush(): void
     {
         $this->initRepository(null, 0);
         $this->initRepository(null, 1);
@@ -850,7 +849,7 @@ class RepositoryTest extends TestCase
         $this->assertEquals($r1->getMainBranch()->getSha(), $r3->getLog()->last()->getSha());
     }
 
-    public function testRevParse()
+    public function testRevParse(): void
     {
         $this->initRepository(null, 0);
         $r = $this->getRepository(0);
@@ -862,7 +861,7 @@ class RepositoryTest extends TestCase
         $this->assertEquals($master->getSha(), $revParse[0]);
     }
 
-    public function testIsBare()
+    public function testIsBare(): void
     {
         $this->initRepository(null, 0);
         $r = $this->getRepository(0);
@@ -884,7 +883,7 @@ class RepositoryTest extends TestCase
      * @covers \GitElephant\Repository::getGlobalConfigs
      * @covers \GitElephant\Repository::removeGlobalConfig
      */
-    public function testGlobalConfigs()
+    public function testGlobalConfigs(): void
     {
         $repo = $this->getRepository();
 
@@ -909,7 +908,7 @@ class RepositoryTest extends TestCase
     /**
      * test reset
      */
-    public function testResetHard()
+    public function testResetHard(): void
     {
         $this->initRepository();
         $repo = $this->getRepository();
@@ -931,7 +930,7 @@ class RepositoryTest extends TestCase
     /**
      * test reset
      */
-    public function testResetSoft()
+    public function testResetSoft(): void
     {
         $this->initRepository();
         $repo = $this->getRepository();
@@ -957,7 +956,7 @@ class RepositoryTest extends TestCase
      * @covers \GitElephant\Repository::getGlobalOptions
      * @covers \GitElephant\Repository::removeGlobalOption
      */
-    public function testGlobalOptions()
+    public function testGlobalOptions(): void
     {
         $repo = $this->getRepository();
 
@@ -986,7 +985,7 @@ class RepositoryTest extends TestCase
      * @covers \GitElephant\Repository::getGlobalCommandArguments
      * @covers \GitElephant\Repository::removeGlobalCommandArgument
      */
-    public function testGlobalCommandArguments()
+    public function testGlobalCommandArguments(): void
     {
         $repo = $this->getRepository();
 
@@ -1011,7 +1010,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::stash
      */
-    public function testStashThrowsExceptionIfNoCommits()
+    public function testStashThrowsExceptionIfNoCommits(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -1023,7 +1022,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::stash
      */
-    public function testStash()
+    public function testStash(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -1038,7 +1037,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::stashList
      */
-    public function testStashList()
+    public function testStashList(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -1051,7 +1050,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::stashShow
      */
-    public function testStashShow()
+    public function testStashShow(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -1064,7 +1063,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::stashDrop
      */
-    public function testStashDrop()
+    public function testStashDrop(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -1078,7 +1077,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::stashPop
      */
-    public function testStashPop()
+    public function testStashPop(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -1093,7 +1092,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::stashApply
      */
-    public function testStashApply()
+    public function testStashApply(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -1108,7 +1107,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::stashBranch
      */
-    public function testStashBranch()
+    public function testStashBranch(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -1122,7 +1121,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::stashCreate
      */
-    public function testStashCreate()
+    public function testStashCreate(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');
@@ -1134,7 +1133,7 @@ class RepositoryTest extends TestCase
     /**
      * @covers \GitElephant\Repository::stashCreate
      */
-    public function testStashClear()
+    public function testStashClear(): void
     {
         $this->getRepository()->init();
         $this->addFile('test');

--- a/tests/GitElephant/RepositoryTest.php
+++ b/tests/GitElephant/RepositoryTest.php
@@ -157,8 +157,7 @@ class RepositoryTest extends TestCase
         $this->assertStringEndsWith('master', $output[0]);
         $this->addFile('file2');
         $output = $this->getRepository()->getStatusOutput();
-        // $this->assertContains('file2', $output);
-        $this->assertStringEndsWith('file2', $output[3]);
+        $this->assertContains('file2', $output);
     }
 
     /**
@@ -687,7 +686,7 @@ class RepositoryTest extends TestCase
         $this->getRepository()->commit('commit 1', true);
         $this->getRepository()->move('foo', 'bar');
         $status = $this->getRepository()->getStatusOutput();
-        $this->assertRegExp('/(.*):    foo -> bar/', $status[3]);
+        $this->assertRegExp('/(.*):    foo -> bar/', implode("\n", $status));
     }
 
     /**
@@ -701,7 +700,7 @@ class RepositoryTest extends TestCase
         $this->getRepository()->remove('foo');
         $status = $this->getRepository()->getStatusOutput();
 
-        $this->assertRegExp('/(.*):    foo/', $status[3]);
+        $this->assertRegExp('/(.*):    foo/', implode("\n", $status));
     }
 
     /**

--- a/tests/GitElephant/Status/StatusTest.php
+++ b/tests/GitElephant/Status/StatusTest.php
@@ -30,7 +30,7 @@ class StatusTest extends TestCase
     /**
      * testStatusIndexWithoutUntracked
      */
-    public function testStatusIndexWithoutUntracked()
+    public function testStatusIndexWithoutUntracked(): void
     {
         $this->addFile('test');
         $s = $this->repository->getIndexStatus();
@@ -41,7 +41,7 @@ class StatusTest extends TestCase
     /**
      * status test
      */
-    public function testUntracked()
+    public function testUntracked(): void
     {
         $this->addFile('test');
         $s = $this->repository->getStatus();
@@ -58,7 +58,7 @@ class StatusTest extends TestCase
     /**
      * modified
      */
-    public function testModified()
+    public function testModified(): void
     {
         $this->addFile('test', null, 'test');
         $this->repository->stage();
@@ -75,7 +75,7 @@ class StatusTest extends TestCase
     /**
      * added
      */
-    public function testAdded()
+    public function testAdded(): void
     {
         $this->addFile('test');
         $this->repository->stage();
@@ -91,7 +91,7 @@ class StatusTest extends TestCase
     /**
      * deleted
      */
-    public function testDeleted()
+    public function testDeleted(): void
     {
         $this->addFile('test');
         $this->repository->commit('test message', true);
@@ -108,7 +108,7 @@ class StatusTest extends TestCase
     /**
      * renamed
      */
-    public function testRenamed()
+    public function testRenamed(): void
     {
         $this->addFile('test', null, 'test content');
         $this->repository->commit('test message', true);
@@ -125,7 +125,7 @@ class StatusTest extends TestCase
     /**
      * testWorkingTreeStatus
      */
-    public function testWorkingTreeStatus()
+    public function testWorkingTreeStatus(): void
     {
         /*$this->markTestSkipped(
             'Caller::execute throws a RuntimeException here because. Repository::unstage
@@ -188,7 +188,7 @@ On new git version this is not happening anymore.'
     /**
      * @param mixed $subject
      */
-    private function assertInterfaces($subject)
+    private function assertInterfaces($subject): void
     {
         $this->assertInstanceOf('\Countable', $subject);
         $this->assertInstanceOf('\Traversable', $subject);

--- a/tests/GitElephant/TestCase.php
+++ b/tests/GitElephant/TestCase.php
@@ -266,7 +266,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
     }
 
     protected function getMockRepository(): \PHPUnit\Framework\MockObject\MockObject
-    {        
+    {
         $mockRepo = $this->getMock(
             Repository::class,
             array(),

--- a/tests/GitElephant/UtilitiesTest.php
+++ b/tests/GitElephant/UtilitiesTest.php
@@ -35,7 +35,7 @@ final class UtilitiesTest extends TestCase
      *
      * @covers \GitElephant\Utilities::pregSplitArray
      */
-    public function testPregSplitArray(array $expected, array $list, string $pattern)
+    public function testPregSplitArray(array $expected, array $list, string $pattern): void
     {
         $this->assertEquals(
             $expected,
@@ -49,7 +49,7 @@ final class UtilitiesTest extends TestCase
     /**
      * @dataProvider
      */
-    public function testPregSplitFlatArray()
+    public function testPregSplitFlatArray(): void
     {
         $this->assertEquals(
             [


### PR DESCRIPTION
This PR 

 - would fix #162 by enabling Symfony 5 as a dependency as well as 
 - fix compatibility with PHPUnit 9. 
 - Additionally, I allowed myself to run [rector](https://github.com/rectorphp/rector) with a few configurations to improve the code style 
- and add return types, to simplify the IDEs job. 
 - Finally, I added GitHub action to check for the code style mentioned in the README by matteo, so we know when a PR does not fulfill it.