### PR TITLE
Update Symfony components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
     ],
     "require": {
         "php": ">=7.2.0",
-        "symfony/process": "~3.4|~4.0|~5.0",
-        "symfony/filesystem": "~3.4|~4.0|~5.0",
-        "symfony/finder": "~3.4|~4.0|~5.0",
+        "symfony/process": "~3.4|~4.0|~5.0|~6.0",
+        "symfony/filesystem": "~3.4|~4.0|~5.0|~6.0",
+        "symfony/finder": "~3.4|~4.0|~5.0|~6.0",
         "phpcollection/phpcollection": "~0.4|~0.5"
     },
     "require-dev": {


### PR DESCRIPTION
The package wasn't installable in projects where `symfony/*:^6.0` components are required. I updated all Symfony components dependencies to include `~6.0`.