### PR TITLE
Upgrade to support PHP 8.2, initial branches other than 'master'

### DIFF
--- a/.github/workflows/static_tests.yml
+++ b/.github/workflows/static_tests.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.3
+          php-version: 8.1
           coverage: none # disable xdebug, pcov
       - run: composer install --no-progress
       - run: ./vendor/bin/phpstan analyse -c phpstan.neon

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,8 +12,9 @@ jobs:
     strategy:
       matrix:
         php:
-          - "7.4"
           - "8.0"
+          - "8.1"
+          - "8.2"
         symfony:
           - 5.*
           - 6.*
@@ -21,7 +22,7 @@ jobs:
           # - prefer-lowest
           - prefer-stable
         exclude:
-          - {php: "7.4", symfony: "6.*"}
+          - {php: "8.2", symfony: "5.*"}
 
     name: PHP ${{ matrix.php }} - S ${{ matrix.symfony }} - ${{ matrix.dependency-version }} - tests
     steps:

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "An abstraction layer for git written in PHP",
     "scripts": {
         "tests": "./vendor/bin/phpunit",
+        "static-tests": "./vendor/bin/phpstan analyse -c phpstan.neon",
         "check-cs": "./vendor/bin/ecs check",
         "fix-cs": "./vendor/bin/ecs check --fix"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="tests/bootstrap.php"
-        colors="true"
-        stopOnFailure="true">
-    <testsuites>
-        <testsuite name="GitElephant Test Suite">
-            <directory>tests/GitElephant/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src/GitElephant/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" colors="true" stopOnFailure="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src/GitElephant/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="GitElephant Test Suite">
+      <directory>tests/GitElephant/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/GitElephant/Command/MainCommand.php
+++ b/src/GitElephant/Command/MainCommand.php
@@ -60,11 +60,14 @@ class MainCommand extends BaseCommand
      * @throws \RuntimeException
      * @return string
      */
-    public function init($bare = false): string
+    public function init($bare = false, ?string $initialBranchName = null): string
     {
         $this->clearAll();
         if ($bare) {
             $this->addCommandArgument('--bare');
+        }
+        if ($initialBranchName) {
+            $this->addCommandArgument('--initial-branch=' . $initialBranchName);
         }
         $this->addCommandName(self::GIT_INIT);
 

--- a/src/GitElephant/Objects/Diff/Diff.php
+++ b/src/GitElephant/Objects/Diff/Diff.php
@@ -196,7 +196,7 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
      *
      * @return null|mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->diffObjects[$offset]) ? $this->diffObjects[$offset] : null;
     }
@@ -241,7 +241,7 @@ class Diff implements \ArrayAccess, \Countable, \Iterator
      *
      * @return mixed
      */
-    public function current()
+    public function current(): mixed
     {
         return $this->diffObjects[$this->position];
     }

--- a/src/GitElephant/Objects/Diff/DiffChunk.php
+++ b/src/GitElephant/Objects/Diff/DiffChunk.php
@@ -238,7 +238,7 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
      *
      * @return DiffChunkLine|null
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): ?DiffChunkLine
     {
         return isset($this->lines[$offset]) ? $this->lines[$offset] : null;
     }
@@ -281,9 +281,9 @@ class DiffChunk implements \ArrayAccess, \Countable, \Iterator
     /**
      * Iterator interface
      *
-     * @return mixed
+     * @return DiffChunkLine|null
      */
-    public function current()
+    public function current(): ?DiffChunkLine
     {
         return $this->lines[$this->position];
     }

--- a/src/GitElephant/Objects/Diff/DiffObject.php
+++ b/src/GitElephant/Objects/Diff/DiffObject.php
@@ -276,7 +276,7 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return DiffChunk|null
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): ?DiffChunk
     {
         return isset($this->chunks[$offset]) ? $this->chunks[$offset] : null;
     }
@@ -319,9 +319,9 @@ class DiffObject implements \ArrayAccess, \Countable, \Iterator
     /**
      * Iterator interface
      *
-     * @return mixed
+     * @return DiffChunk|null
      */
-    public function current()
+    public function current(): ?DiffChunk
     {
         return $this->chunks[$this->position];
     }

--- a/src/GitElephant/Objects/NodeObject.php
+++ b/src/GitElephant/Objects/NodeObject.php
@@ -71,7 +71,7 @@ class NodeObject implements TreeishInterface
     /**
      * name
      *
-     * @var string
+     * @var string|null
      */
     private $name;
 
@@ -255,7 +255,7 @@ class NodeObject implements TreeishInterface
     public function getFullPath(): string
     {
         return rtrim(
-            '' == $this->path ? $this->name : $this->path . DIRECTORY_SEPARATOR . $this->name,
+            ('' == $this->path ? $this->name : $this->path . DIRECTORY_SEPARATOR . $this->name) ?? '',
             DIRECTORY_SEPARATOR
         );
     }

--- a/src/GitElephant/Objects/Remote.php
+++ b/src/GitElephant/Objects/Remote.php
@@ -266,7 +266,7 @@ class Remote
         $configuredRefs = [];
         arsort($groupLines);
         foreach ($groupLines as $type => $lineno) {
-            $configuredRefs[$type] = $lineno === NULL ? [] : array_splice($remoteDetails, $lineno);
+            $configuredRefs[$type] = $lineno === null ? [] : array_splice($remoteDetails, $lineno);
             array_shift($configuredRefs[$type]);
         }
 

--- a/src/GitElephant/Objects/Tree.php
+++ b/src/GitElephant/Objects/Tree.php
@@ -450,7 +450,7 @@ class Tree extends NodeObject implements \ArrayAccess, \Countable, \Iterator
      *
      * @return NodeObject|null
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return isset($this->children[$offset]) ? $this->children[$offset] : null;
     }

--- a/src/GitElephant/Repository.php
+++ b/src/GitElephant/Repository.php
@@ -186,9 +186,9 @@ class Repository
      * @throws \Symfony\Component\Process\Exception\RuntimeException
      * @return Repository
      */
-    public function init($bare = false): self
+    public function init($bare = false, ?string $initialBranchName = null): self
     {
-        $this->caller->execute(MainCommand::getInstance($this)->init($bare));
+        $this->caller->execute(MainCommand::getInstance($this)->init($bare, $initialBranchName));
 
         return $this;
     }

--- a/tests/GitElephant/Command/BranchCommandTest.php
+++ b/tests/GitElephant/Command/BranchCommandTest.php
@@ -30,7 +30,7 @@ class BranchCommandTest extends TestCase
     public function setUp(): void
     {
         $this->initRepository();
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('first commit', true);
     }

--- a/tests/GitElephant/Command/CallerTest.php
+++ b/tests/GitElephant/Command/CallerTest.php
@@ -88,7 +88,7 @@ class CallerTest extends TestCase
     public function testOutputLines(): void
     {
         $caller = new Caller(null, $this->getRepository()->getPath());
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         for ($i = 1; $i <= 50; $i++) {
             $this->addFile('test' . $i, null, 'this is the content');
         }
@@ -104,10 +104,10 @@ class CallerTest extends TestCase
      */
     public function testGetRawOutput(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $caller = new Caller(null, $this->getRepository()->getPath());
         $caller->execute('status');
-        $this->myAssertMatchesRegularExpression('/master/', $caller->getRawOutput());
+        $this->myAssertMatchesRegularExpression('/master|main/', $caller->getRawOutput());
     }
 
     /**

--- a/tests/GitElephant/Command/CatFileCommandTest.php
+++ b/tests/GitElephant/Command/CatFileCommandTest.php
@@ -30,7 +30,7 @@ class CatFileCommandTest extends TestCase
     public function setUp(): void
     {
         $this->initRepository();
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test', null, 'test content');
         $this->addFolder('test-folder');
         $this->addFile('test2', 'test-folder', 'test content 2');

--- a/tests/GitElephant/Command/DiffCommandTest.php
+++ b/tests/GitElephant/Command/DiffCommandTest.php
@@ -34,7 +34,7 @@ class DiffCommandTest extends TestCase
     public function setUp(): void
     {
         $this->initRepository();
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('foo');
         $this->getRepository()->commit('first commit', true);
         $this->diffCommand = new DiffCommand();
@@ -45,7 +45,7 @@ class DiffCommandTest extends TestCase
      */
     public function testDiff(): void
     {
-        $commit = $this->getRepository()->init()->getCommit();
+        $commit = $this->getRepository()->init(false, 'master')->getCommit();
         $this->assertEquals(
             DiffCommand::DIFF_COMMAND . " '--full-index' '--no-color' '--no-ext-diff' '-M' '--dst-prefix=DST/' '--src-prefix=SRC/' 'HEAD^..HEAD'",
             $this->diffCommand->diff('HEAD')

--- a/tests/GitElephant/Command/DiffTreeCommandTest.php
+++ b/tests/GitElephant/Command/DiffTreeCommandTest.php
@@ -29,7 +29,7 @@ class DiffTreeCommandTest extends TestCase
     public function setUp(): void
     {
         $this->initRepository();
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('foo');
         $this->getRepository()->commit('first commit', true);
     }

--- a/tests/GitElephant/Command/FetchCommandTest.php
+++ b/tests/GitElephant/Command/FetchCommandTest.php
@@ -37,7 +37,7 @@ class FetchCommandTest extends TestCase
     public function setUp(): void
     {
         $this->initRepository();
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('test', true);
     }

--- a/tests/GitElephant/Command/LogCommandTest.php
+++ b/tests/GitElephant/Command/LogCommandTest.php
@@ -29,7 +29,7 @@ class LogCommandTest extends TestCase
     public function setUp(): void
     {
         $this->initRepository();
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('foo');
         $this->addFolder('test-folder');
         $this->addFile('test-file', 'test-folder', 'test');
@@ -41,7 +41,9 @@ class LogCommandTest extends TestCase
      */
     public function testShowObjectLog(): void
     {
-        $branch = $this->getRepository()->getBranch('master');
+        // TODO: generalize the "main" branch fetch
+        $branchName = 'master';
+        $branch = $this->getRepository()->getBranch($branchName);
         $obj = $this->getRepository()->getTree('HEAD', 'test-folder/test-file')->getBlob();
         $lc = LogCommand::getInstance();
         $this->assertEquals(
@@ -49,7 +51,7 @@ class LogCommandTest extends TestCase
             $lc->showObjectLog($obj)
         );
         $this->assertEquals(
-            "log '-s' '--pretty=raw' '--no-color' 'master' -- 'test-folder/test-file'",
+            "log '-s' '--pretty=raw' '--no-color' '$branchName' -- 'test-folder/test-file'",
             $lc->showObjectLog($obj, $branch)
         );
     }

--- a/tests/GitElephant/Command/MergeCommandTest.php
+++ b/tests/GitElephant/Command/MergeCommandTest.php
@@ -24,7 +24,7 @@ class MergeCommandTest extends TestCase
     public function setUp(): void
     {
         $this->initRepository();
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('test', true);
         $this->getRepository()->createBranch('test', 'master');

--- a/tests/GitElephant/Command/MvCommandTest.php
+++ b/tests/GitElephant/Command/MvCommandTest.php
@@ -23,7 +23,7 @@ class MvCommandTest extends TestCase
      */
     public function setUp(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->addFolder('test_folder');
         $this->addFile('test2', 'test_folder');

--- a/tests/GitElephant/Command/PullCommandTest.php
+++ b/tests/GitElephant/Command/PullCommandTest.php
@@ -38,7 +38,7 @@ class PullCommandTest extends TestCase
     public function setUp(): void
     {
         $this->initRepository();
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('test', true);
     }

--- a/tests/GitElephant/Command/PushCommandTest.php
+++ b/tests/GitElephant/Command/PushCommandTest.php
@@ -38,7 +38,7 @@ class PushCommandTest extends TestCase
     public function setUp(): void
     {
         $this->initRepository();
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('test', true);
     }

--- a/tests/GitElephant/Command/RemoteCommandTest.php
+++ b/tests/GitElephant/Command/RemoteCommandTest.php
@@ -33,7 +33,7 @@ class RemoteCommandTest extends TestCase
     {
         $this->initRepository();
         $repo = $this->getRepository();
-        $repo->init();
+        $repo->init(false, 'master');
         $this->addFile('test');
         $repo->commit('test', true);
         $repo->createTag($this->startTagName);

--- a/tests/GitElephant/Command/ResetCommandTest.php
+++ b/tests/GitElephant/Command/ResetCommandTest.php
@@ -19,7 +19,7 @@ class ResetCommandTest extends TestCase
     public function setUp(): void
     {
         $this->initRepository();
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('test', true);
         $this->getRepository()->createBranch('test', 'master');

--- a/tests/GitElephant/Command/RevParseCommandTest.php
+++ b/tests/GitElephant/Command/RevParseCommandTest.php
@@ -37,7 +37,7 @@ class RevParseCommandTest extends TestCase
     {
         $this->initRepository(null, 0);
         $repo = $this->getRepository(0);
-        $repo->init();
+        $repo->init(false, 'master');
 
         $options = [RevParseCommand::OPTION_IS_BARE_REPOSIORY];
         $c = RevParseCommand::getInstance()->revParse(null, $options);

--- a/tests/GitElephant/Objects/BranchTest.php
+++ b/tests/GitElephant/Objects/BranchTest.php
@@ -69,7 +69,7 @@ class BranchTest extends TestCase
      */
     public function testConstructor(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('test commit', true);
         $b = new Branch($this->getRepository(), 'master');
@@ -90,7 +90,7 @@ class BranchTest extends TestCase
      */
     public function testBranchCreate(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('test', true);
         Branch::create($this->getRepository(), 'test-branch');
@@ -103,7 +103,7 @@ class BranchTest extends TestCase
      */
     public function testToString(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('test commit', true);
         $b = Branch::checkout($this->getRepository(), 'master');
@@ -115,7 +115,7 @@ class BranchTest extends TestCase
      */
     public function testCreate(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->repository->commit('test', true);
         $this->assertCount(1, $this->repository->getBranches(true));

--- a/tests/GitElephant/Objects/CommitTest.php
+++ b/tests/GitElephant/Objects/CommitTest.php
@@ -182,7 +182,7 @@ class CommitTest extends TestCase
      */
     public function testCreate(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->repository->stage();
         $commit = Commit::create($this->repository, 'first commit', true);
@@ -194,7 +194,7 @@ class CommitTest extends TestCase
      */
     public function testGetDiff(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->repository->stage();
         $commit = Commit::create($this->repository, 'first commit', true);
@@ -213,7 +213,7 @@ class CommitTest extends TestCase
 
     public function testRevParse(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->repository->stage();
         $commit = Commit::create($this->repository, 'first commit', true);
@@ -224,7 +224,7 @@ class CommitTest extends TestCase
 
     public function testCommitWithoutTag(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->repository->stage();
         $commit = Commit::create($this->repository, 'first commit', true);
@@ -233,7 +233,7 @@ class CommitTest extends TestCase
 
     public function testCommitWithTag(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->repository->stage();
         $commit = Commit::create($this->repository, 'first commit', true);

--- a/tests/GitElephant/Objects/Diff/DiffTest.php
+++ b/tests/GitElephant/Objects/Diff/DiffTest.php
@@ -30,7 +30,7 @@ class DiffTest extends TestCase
 
     public function testDiff(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('foo', null, "content line 1\ncontent line 2\ncontent line 3");
         $this->getRepository()->commit('commit1', true);
         $this->addFile('foo', null, "content line 1\ncontent line 2 changed");

--- a/tests/GitElephant/Objects/LogRangeTest.php
+++ b/tests/GitElephant/Objects/LogRangeTest.php
@@ -45,7 +45,7 @@ class LogRangeTest extends TestCase
         $this->initRepository(null, 0);
         $this->initRepository(null, 1);
         $r1 = $this->getRepository(0);
-        $r1->init();
+        $r1->init(false, 'master');
 
         for ($i = 0; $i < 10; $i++) {
             $this->addFile('test file ' . $i, null, null, $r1);

--- a/tests/GitElephant/Objects/LogTest.php
+++ b/tests/GitElephant/Objects/LogTest.php
@@ -28,7 +28,7 @@ class LogTest extends TestCase
      */
     public function setUp(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
 
         for ($i = 0; $i < 10; $i++) {
             $this->addFile('test file ' . $i);

--- a/tests/GitElephant/Objects/NodeObjectTest.php
+++ b/tests/GitElephant/Objects/NodeObjectTest.php
@@ -13,7 +13,7 @@ class NodeObjectTest extends TestCase
     public function setUp(): void
     {
         $this->initRepository();
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test-file');
         $this->getRepository()->commit('first commit', true);
     }

--- a/tests/GitElephant/Objects/RemoteTest.php
+++ b/tests/GitElephant/Objects/RemoteTest.php
@@ -46,7 +46,7 @@ class RemoteTest extends TestCase
     {
         $this->initRepository();
         $repo = $this->getRepository();
-        $repo->init();
+        $repo->init(false, 'master');
         $this->addFile('test');
         $repo->commit('test', true);
         $repo->createTag($this->startTagName);

--- a/tests/GitElephant/Objects/TagTest.php
+++ b/tests/GitElephant/Objects/TagTest.php
@@ -19,7 +19,7 @@ class TagTest extends TestCase
      */
     public function testTag(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('foo');
         $this->getRepository()->commit('commit1', true);
         $this->getRepository()->createTag('test-tag');
@@ -35,7 +35,7 @@ class TagTest extends TestCase
      */
     public function testTagFromStartPoint(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('foo');
         $this->repository->commit('commit1', true);
         Tag::create($this->repository, 'tag1', $this->repository->getCommit());
@@ -54,7 +54,7 @@ class TagTest extends TestCase
     public function testNonExistentTag(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('foo');
         $this->getRepository()->commit('commit1', true);
         $this->getRepository()->createTag('test-tag');
@@ -66,7 +66,7 @@ class TagTest extends TestCase
      */
     public function testCreate(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->repository->commit('test', true);
         $this->assertCount(0, $this->repository->getTags());

--- a/tests/GitElephant/Objects/TreeObjectTest.php
+++ b/tests/GitElephant/Objects/TreeObjectTest.php
@@ -9,7 +9,7 @@ class TreeObjectTest extends TestCase
     public function setUp(): void
     {
         $this->initRepository();
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFolder('test');
         $this->addFile('test-file', 'test');
         $this->getRepository()->commit('first commit', true);

--- a/tests/GitElephant/Objects/TreeTest.php
+++ b/tests/GitElephant/Objects/TreeTest.php
@@ -32,7 +32,7 @@ class TreeTest extends TestCase
     public function setUp(): void
     {
         $this->initRepository();
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFolder('test');
         $this->addFile('test/1');
         $this->addFile('test/1-2');
@@ -95,7 +95,7 @@ class TreeTest extends TestCase
         unlink($path);
         mkdir($path);
         $repository = new Repository($path);
-        $repository->init();
+        $repository->init(false, 'master');
         $repository->addSubmodule($this->repository->getPath());
         $repository->commit('test', true);
         $tree = $repository->getTree();
@@ -111,7 +111,7 @@ class TreeTest extends TestCase
     public function testIsRoot(): void
     {
         $this->initRepository();
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFolder('test');
         $this->addFile('test/1');
         $this->getRepository()->commit('test', true);

--- a/tests/GitElephant/RepositoryTest.php
+++ b/tests/GitElephant/RepositoryTest.php
@@ -56,7 +56,7 @@ class RepositoryTest extends TestCase
      */
     public function testInit(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $match = false;
 
         // Force US/EN locale
@@ -84,7 +84,7 @@ class RepositoryTest extends TestCase
      */
     public function testStage(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->stage();
         $match = false;
@@ -101,7 +101,7 @@ class RepositoryTest extends TestCase
      */
     public function testUnstage(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('first commit', true);
         $this->addFile('test2');
@@ -121,7 +121,7 @@ class RepositoryTest extends TestCase
      */
     public function testCommit(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->stage();
         $this->getRepository()->commit('initial import');
@@ -156,7 +156,7 @@ class RepositoryTest extends TestCase
      */
     public function testGetStatus(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('test commit', true);
         $output = $this->getRepository()->getStatusOutput();
@@ -171,7 +171,7 @@ class RepositoryTest extends TestCase
      */
     public function testCreateBranch(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('foo', true);
         $this->getRepository()->createBranch('test-branch');
@@ -183,7 +183,7 @@ class RepositoryTest extends TestCase
      */
     public function testDeleteBranch(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test-file');
         $this->getRepository()->commit('test', true);
         $this->getRepository()->createBranch('branch2');
@@ -203,7 +203,7 @@ class RepositoryTest extends TestCase
      */
     public function testGetBranches(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->stage();
         $this->getRepository()->commit('initial import', true);
@@ -245,7 +245,7 @@ class RepositoryTest extends TestCase
      */
     public function testGetMainBranch(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test-file');
         $this->getRepository()->commit('test', true);
         $this->assertEquals('master', $this->getRepository()->getMainBranch()->getName());
@@ -256,7 +256,7 @@ class RepositoryTest extends TestCase
      */
     public function testGetBranch(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test-file');
         $this->getRepository()->commit('test', true);
         $this->assertInstanceOf('GitElephant\Objects\Branch', $this->getRepository()->getBranch('master'));
@@ -268,7 +268,7 @@ class RepositoryTest extends TestCase
      */
     public function testMerge(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test-file');
         $this->getRepository()->commit('test', true);
         $this->assertEquals(1, count($this->getRepository()->getTree()));
@@ -317,7 +317,7 @@ class RepositoryTest extends TestCase
      */
     public function testTags(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test-file');
         $this->getRepository()->commit('test', true);
         $this->assertEquals(0, count($this->getRepository()->getTags()));
@@ -334,7 +334,7 @@ class RepositoryTest extends TestCase
      */
     public function testGetLastTag(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test-file');
         $this->getRepository()->commit('test', true);
         $this->getRepository()->createTag('0.0.2');
@@ -359,7 +359,7 @@ class RepositoryTest extends TestCase
      */
     public function testGetCommit(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test-file');
         $this->getRepository()->commit('test', true);
         $this->assertInstanceOf('GitElephant\Objects\Commit', $this->getRepository()->getCommit());
@@ -367,7 +367,7 @@ class RepositoryTest extends TestCase
 
     public function testGetBranchOrTag(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test-file');
         $this->getRepository()->commit('test', true);
         $this->getRepository()->createBranch('branch2');
@@ -383,7 +383,7 @@ class RepositoryTest extends TestCase
     public function testGetObjectLog(): void
     {
         $repo = $this->getRepository();
-        $repo->init();
+        $repo->init(false, 'master');
 
         $this->addFolder('test');
 
@@ -425,7 +425,7 @@ class RepositoryTest extends TestCase
     public function testGetObjectLogFolders(): void
     {
         $repo = $this->getRepository();
-        $repo->init();
+        $repo->init(false, 'master');
 
         $this->addFolder('A');
         $this->addFile('A1.txt', 'A');
@@ -466,7 +466,7 @@ class RepositoryTest extends TestCase
     public function testGetObjectLogBranches(): void
     {
         $repo = $this->getRepository();
-        $repo->init();
+        $repo->init(false, 'master');
 
         $this->addFolder('A');
         $this->addFile('A1.txt', 'A');
@@ -505,7 +505,7 @@ class RepositoryTest extends TestCase
      */
     public function testGetLog(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
 
         for ($i = 0; $i < 50; $i++) {
             $this->addFile('test file ' . $i);
@@ -522,7 +522,7 @@ class RepositoryTest extends TestCase
      */
     public function testGetLogForBranch(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test file 0');
         $this->getRepository()->commit('first commit', true);
         $this->getRepository()->checkout('test-branch', true);
@@ -542,7 +542,7 @@ class RepositoryTest extends TestCase
      */
     public function testCheckout(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test-file');
         $this->getRepository()->commit('test', true);
         $this->assertEquals('master', $this->getRepository()->getMainBranch()->getName());
@@ -556,7 +556,7 @@ class RepositoryTest extends TestCase
      */
     public function testCheckoutTag(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test-file');
         $this->getRepository()->commit('test', true);
         $this->getRepository()->createTag('v0.0.1');
@@ -578,7 +578,7 @@ class RepositoryTest extends TestCase
      */
     public function testGetTree(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->addFolder('test-folder');
         $this->addFile('test2', 'test-folder');
@@ -636,7 +636,7 @@ class RepositoryTest extends TestCase
      */
     public function testGetDiff(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test-file');
         $this->getRepository()->commit('commit 1', true);
         $commit1 = $this->getRepository()->getCommit();
@@ -658,7 +658,7 @@ class RepositoryTest extends TestCase
         $this->initRepository(null, 0);
         $this->initRepository(null, 1);
         $remote = $this->getRepository(0);
-        $remote->init();
+        $remote->init(false, 'master');
         $this->addFile('test', null, null, $remote);
         $remote->commit('test', true);
         $local = $this->getRepository(1);
@@ -674,7 +674,7 @@ class RepositoryTest extends TestCase
     public function testOutputContent(): void
     {
         $this->initRepository();
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('file1', null, 'file content');
         $this->getRepository()->commit('first commit', true);
         $branch = $this->getRepository()->getBranch('master');
@@ -688,7 +688,7 @@ class RepositoryTest extends TestCase
      */
     public function testMove(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('foo');
         $this->getRepository()->commit('commit 1', true);
         $this->getRepository()->move('foo', 'bar');
@@ -701,7 +701,7 @@ class RepositoryTest extends TestCase
      */
     public function testRemove(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('foo');
         $this->getRepository()->commit('commit 1', true);
         $this->getRepository()->remove('foo');
@@ -715,7 +715,7 @@ class RepositoryTest extends TestCase
      */
     public function testCountCommits(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('foo');
         $this->getRepository()->commit('commit 1', true);
         $this->assertEquals(1, $this->getRepository()->countCommits());
@@ -748,7 +748,7 @@ class RepositoryTest extends TestCase
     {
         $this->initRepository(null, 0);
         $remote = $this->getRepository(0);
-        $remote->init();
+        $remote->init(false, 'master');
         $this->addFile('test', null, null, $remote);
         $remote->commit('test', true);
         $remote->createBranch('develop');
@@ -776,7 +776,7 @@ class RepositoryTest extends TestCase
         $remote = $this->getRepository(0);
         $remote->init(true);
         $this->initRepository();
-        $this->repository->init();
+        $this->repository->init(false, 'master');
         $this->repository->addRemote('github', $remote->getPath());
         $this->assertInstanceOf('GitElephant\Objects\Remote', $this->repository->getRemote('github'));
         $this->repository->addRemote('github2', $remote->getPath());
@@ -791,7 +791,7 @@ class RepositoryTest extends TestCase
         $this->initRepository(null, 0);
         $this->initRepository(null, 1);
         $r1 = $this->getRepository(0);
-        $r1->init();
+        $r1->init(false, 'master');
         $this->addFile('test1', null, null, $r1);
         $r1->commit('test commit', true);
         $r1->createBranch('tag-test');
@@ -799,7 +799,7 @@ class RepositoryTest extends TestCase
         $r1->commit('another test commit', true);
         $r1->createTag('test-tag');
         $r2 = $this->getRepository(1);
-        $r2->init();
+        $r2->init(false, 'master');
         $r2->addRemote('origin', $r1->getPath());
         $this->assertEmpty($r2->getBranches(true, true));
         $r2->fetch();
@@ -816,11 +816,11 @@ class RepositoryTest extends TestCase
         $this->initRepository(null, 0);
         $this->initRepository(null, 1);
         $r1 = $this->getRepository(0);
-        $r1->init();
+        $r1->init(false, 'master');
         $this->addFile('test1', null, null, $r1);
         $r1->commit('test commit', true);
         $r2 = $this->getRepository(1);
-        $r2->init();
+        $r2->init(false, 'master');
         $r2->addRemote('origin', $r1->getPath());
         $r2->pull('origin', 'master');
         $this->assertEquals('test commit', $r2->getLog()->last()->getMessage());
@@ -837,7 +837,7 @@ class RepositoryTest extends TestCase
         $this->initRepository(null, 2);
         // commit on r1
         $r1 = $this->getRepository(0);
-        $r1->init();
+        $r1->init(false, 'master');
         $this->addFile('test1', null, null, $r1);
         $r1->commit('test commit', true);
         // push from r1 to r2
@@ -847,7 +847,7 @@ class RepositoryTest extends TestCase
         $r1->push('origin', 'master');
         // pull from r2 to r3 should get the same result
         $r3 = $this->getRepository(2);
-        $r3->init();
+        $r3->init(false, 'master');
         $r3->addRemote('origin', $r2->getPath());
         $r3->pull('origin', 'master');
 
@@ -859,7 +859,7 @@ class RepositoryTest extends TestCase
     {
         $this->initRepository(null, 0);
         $r = $this->getRepository(0);
-        $r->init();
+        $r->init(false, 'master');
         $this->addFile('test1', null, null, $r);
         $r->commit('test commit', true);
         $master = $r->getBranch('master');
@@ -871,7 +871,7 @@ class RepositoryTest extends TestCase
     {
         $this->initRepository(null, 0);
         $r = $this->getRepository(0);
-        $r->init();
+        $r->init(false, 'master');
 
         $this->assertEquals(false, $r->isBare());
 
@@ -918,7 +918,7 @@ class RepositoryTest extends TestCase
     {
         $this->initRepository();
         $repo = $this->getRepository();
-        $repo->init();
+        $repo->init(false, 'master');
         $this->addFile('file1');
         $repo->stage();
         $repo->commit('message1');
@@ -940,7 +940,7 @@ class RepositoryTest extends TestCase
     {
         $this->initRepository();
         $repo = $this->getRepository();
-        $repo->init();
+        $repo->init(false, 'master');
         $this->addFile('file1');
         $repo->stage();
         $repo->commit('message1');
@@ -1018,7 +1018,7 @@ class RepositoryTest extends TestCase
      */
     public function testStashThrowsExceptionIfNoCommits(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
 
         $this->expectException('RuntimeException');
@@ -1030,7 +1030,7 @@ class RepositoryTest extends TestCase
      */
     public function testStash(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('Test commit', true);
         $this->addFile('test2');
@@ -1045,7 +1045,7 @@ class RepositoryTest extends TestCase
      */
     public function testStashList(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('Test commit', true);
         $this->addFile('test2');
@@ -1058,7 +1058,7 @@ class RepositoryTest extends TestCase
      */
     public function testStashShow(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('Test commit', true);
         $this->addFile('test2');
@@ -1071,7 +1071,7 @@ class RepositoryTest extends TestCase
      */
     public function testStashDrop(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('Test commit', true);
         $this->addFile('test2');
@@ -1085,7 +1085,7 @@ class RepositoryTest extends TestCase
      */
     public function testStashPop(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('Test commit', true);
         $this->addFile('test2');
@@ -1100,7 +1100,7 @@ class RepositoryTest extends TestCase
      */
     public function testStashApply(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('Test commit', true);
         $this->addFile('test2');
@@ -1115,7 +1115,7 @@ class RepositoryTest extends TestCase
      */
     public function testStashBranch(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('Test commit', true);
         $this->addFile('test2');
@@ -1129,7 +1129,7 @@ class RepositoryTest extends TestCase
      */
     public function testStashCreate(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('Test commit', true);
         $objectName = $this->getRepository()->stashCreate();
@@ -1141,7 +1141,7 @@ class RepositoryTest extends TestCase
      */
     public function testStashClear(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('test');
         $this->getRepository()->commit('Test commit', true);
         $this->addFile('test2');

--- a/tests/GitElephant/Status/StatusTest.php
+++ b/tests/GitElephant/Status/StatusTest.php
@@ -23,7 +23,7 @@ class StatusTest extends TestCase
      */
     public function setUp(): void
     {
-        $this->getRepository()->init();
+        $this->getRepository()->init(false, 'master');
         $this->addFile('initial');
         $this->getRepository()->commit('initial commit', true);
     }


### PR DESCRIPTION
This is a minor upgrade, having tests run with PHP 8.0-8.2, rather than 7.3/4. 

The biggest change is the incorporation of supporting an initial branch name (possibly incompatible with certain git versions < 2.2, but only when called in that way), which was needed on my local device where the default branch name is called 'main' rather than 'master'. 